### PR TITLE
Fix crash when dragging to the edge of the screen

### DIFF
--- a/crates/controller/src/mouse.rs
+++ b/crates/controller/src/mouse.rs
@@ -189,7 +189,8 @@ fn update_position(windows: Res<Windows>, mut mouse: ResMut<MousePosition>) {
     mouse.set_position(
         window
             .cursor_position()
-            .map(|position| position / Vec2::new(window.width(), window.height())),
+            .map(|position| position / Vec2::new(window.width(), window.height()))
+            .map(|normalised_position| normalised_position.clamp(Vec2::ZERO, Vec2::ONE)),
     );
 }
 


### PR DESCRIPTION
Previously when dragging near the edge of the window, the game would sometimes crash with the below trace, seemingly due to a small rounding error of around a pixel.
```
thread 'Compute Task Pool (3)' panicked at 'Top right corner is not within screen range: Vec2(-0.22984987, 1.0011313)', crates/core/src/screengeom.rs:49:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/afaf3e07aaa7ca9873bdb439caec53faffa4230c/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/afaf3e07aaa7ca9873bdb439caec53faffa4230c/library/core/src/panicking.rs:64:14
   2: de_core::screengeom::ScreenRect::new
   3: de_core::screengeom::ScreenRect::from_points
```
This change simply clamps the mouse position to within the screen bounds, to avoid this error.