### PR TITLE
Show updated health bars for a short time

### DIFF
--- a/crates/core/src/visibility.rs
+++ b/crates/core/src/visibility.rs
@@ -42,6 +42,11 @@ impl VisibilityFlags {
         self.invisible.set(bit, value);
     }
 
+    /// Returns value of a specific "visible" flag.
+    pub fn visible_value(&self, bit: u32) -> bool {
+        self.visible.get(bit)
+    }
+
     /// Returns value of a specific "invisible" flag.
     pub fn invisible_value(&self, bit: u32) -> bool {
         self.invisible.get(bit)

--- a/crates/signs/src/lib.rs
+++ b/crates/signs/src/lib.rs
@@ -12,6 +12,7 @@ mod pole;
 /// The 3D signs are not displayed if further than this from the camera.
 const MAX_VISIBILITY_DISTANCE: f32 = 140.;
 const DISTANCE_FLAG_BIT: u32 = 0;
+const UPDATE_TIMER_FLAG_BIT: u32 = 2;
 
 pub struct SignsPluginGroup;
 


### PR DESCRIPTION
Implements #388

The bar is set visible using an event, and adds a timer component or updates an existing one. Once the timer expires, the visibility flag is unset and the timer removed.

Feel free to suggest changes, I wrote this very spontaneously.