### PR TITLE
de_net: Ensure prompt task closure

### DIFF
--- a/crates/net/src/tasks/confirmer.rs
+++ b/crates/net/src/tasks/confirmer.rs
@@ -15,6 +15,10 @@ pub(super) async fn run(
     info!("Starting confirmer on port {port}...");
 
     loop {
+        if datagrams.is_closed() {
+            break;
+        }
+
         confirms.clean(Instant::now()).await;
 
         let Ok(next) = confirms

--- a/crates/net/src/tasks/resender.rs
+++ b/crates/net/src/tasks/resender.rs
@@ -17,6 +17,10 @@ pub(super) async fn run(
 
     let mut buf = [0u8; MAX_DATAGRAM_SIZE];
     loop {
+        if datagrams.is_closed() || errors.is_closed() {
+            break;
+        }
+
         resends.clean(Instant::now()).await;
 
         let Ok(resend_result) = resends


### PR DESCRIPTION
The loop might take infinitely to finish in case that 0 messages needed to be resend or confirmed.