### PR TITLE
de_net: Fix network stack shutdown

### DIFF
--- a/crates/net/src/connection/confirms.rs
+++ b/crates/net/src/connection/confirms.rs
@@ -51,6 +51,8 @@ impl Confirmations {
     ///
     /// * `time` - current time.
     ///
+    /// * `force` - if true, all pending confirmations will be sent.
+    ///
     /// * `datagrams` - output datagrams with the confirmations will be send to
     ///   this channel.
     ///
@@ -60,6 +62,7 @@ impl Confirmations {
     pub(crate) async fn send_confirms(
         &mut self,
         time: Instant,
+        force: bool,
         datagrams: &mut Sender<OutDatagram>,
     ) -> Result<Instant, SendError<OutDatagram>> {
         let mut next = Instant::now() + MAX_BUFF_AGE;
@@ -67,7 +70,7 @@ impl Confirmations {
 
         while let Some((addr, buffer)) = book.next() {
             if let Some(expiration) = buffer.expiration() {
-                if expiration <= time || buffer.full() {
+                if force || expiration <= time || buffer.full() {
                     while let Some(data) = buffer.flush(MAX_MESSAGE_SIZE) {
                         datagrams
                             .send(OutDatagram::new(

--- a/crates/net/src/tasks/cancellation.rs
+++ b/crates/net/src/tasks/cancellation.rs
@@ -1,0 +1,27 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+pub(super) struct CancellationSender(Arc<AtomicBool>);
+
+impl Drop for CancellationSender {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
+pub(super) struct CancellationRecv(Arc<AtomicBool>);
+
+impl CancellationRecv {
+    pub(super) fn cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// Creates a cancellation sender / receiver pair. Once the sender gets
+/// dropped, the receiver signals cancellation.
+pub(super) fn cancellation() -> (CancellationSender, CancellationRecv) {
+    let flag = Arc::new(AtomicBool::new(false));
+    (CancellationSender(flag.clone()), CancellationRecv(flag))
+}

--- a/crates/net/src/tasks/ureceiver.rs
+++ b/crates/net/src/tasks/ureceiver.rs
@@ -7,7 +7,7 @@ use async_std::{
 };
 use tracing::{error, info};
 
-use super::dreceiver::InUserDatagram;
+use super::{cancellation::CancellationSender, dreceiver::InUserDatagram};
 use crate::{connection::Confirmations, InMessage};
 
 /// Handler of user datagrams, i.e. datagrams with user data targeted to
@@ -17,6 +17,7 @@ use crate::{connection::Confirmations, InMessage};
 /// channel is closed.
 pub(super) async fn run(
     port: u16,
+    _cancellation: CancellationSender,
     datagrams: Receiver<InUserDatagram>,
     messages: Sender<InMessage>,
     mut confirms: Confirmations,


### PR DESCRIPTION
Before the changes implemented in this commit, confirmer was never properly shut down. Even after all channels (`error`, `inputs` `outputs`) to the networking stack were dropped.