### PR TITLE
de_net: Fix & improve resender termination

### DIFF
--- a/crates/net/src/tasks/mod.rs
+++ b/crates/net/src/tasks/mod.rs
@@ -49,11 +49,11 @@ pub fn startup(network: Network) -> io::Result<Communicator> {
     ));
 
     let (inputs_sender, inputs_receiver) = bounded(CHANNEL_CAPACITY);
-    let (cancellation_sender, cancellation_receiver) = cancellation();
+    let (confirmer_cancellation_sender, confirmer_cancellation_receiver) = cancellation();
     let confirms = Confirmations::new();
     task::spawn(ureceiver::run(
         port,
-        cancellation_sender,
+        confirmer_cancellation_sender,
         in_user_datagrams_receiver,
         inputs_sender,
         confirms.clone(),
@@ -61,8 +61,10 @@ pub fn startup(network: Network) -> io::Result<Communicator> {
 
     let (outputs_sender, outputs_receiver) = bounded(CHANNEL_CAPACITY);
     let (errors_sender, errors_receiver) = bounded(CHANNEL_CAPACITY);
+    let (resender_cancellation_sender, resender_cancellation_receiver) = cancellation();
     task::spawn(resender::run(
         port,
+        resender_cancellation_receiver,
         out_datagrams_sender.clone(),
         errors_sender,
         resends.clone(),
@@ -70,12 +72,13 @@ pub fn startup(network: Network) -> io::Result<Communicator> {
 
     task::spawn(confirmer::run(
         port,
-        cancellation_receiver,
+        confirmer_cancellation_receiver,
         out_datagrams_sender.clone(),
         confirms,
     ));
     task::spawn(usender::run(
         port,
+        resender_cancellation_sender,
         out_datagrams_sender,
         outputs_receiver,
         resends,

--- a/crates/net/src/tasks/resender.rs
+++ b/crates/net/src/tasks/resender.rs
@@ -36,13 +36,13 @@ pub(super) async fn run(
         };
 
         if !errors.is_closed() {
-            for target in resend_result.failures {
+            'failures: for target in resend_result.failures {
                 let result = errors.send(ConnectionError::new(target)).await;
                 if result.is_err() {
                     if cancellation.cancelled() {
                         break 'main;
                     } else {
-                        continue 'main;
+                        break 'failures;
                     }
                 }
             }

--- a/crates/net/src/tasks/usender.rs
+++ b/crates/net/src/tasks/usender.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use async_std::channel::{Receiver, Sender};
 use tracing::info;
 
-use super::dsender::OutDatagram;
+use super::{cancellation::CancellationSender, dsender::OutDatagram};
 use crate::{
     connection::Resends,
     header::{DatagramHeader, DatagramId},
@@ -13,6 +13,7 @@ use crate::{
 /// Handler & scheduler of datagram resends.
 pub(super) async fn run(
     port: u16,
+    _cancellation: CancellationSender,
     datagrams: Sender<OutDatagram>,
     messages: Receiver<OutMessage>,
     mut resends: Resends,


### PR DESCRIPTION
There was a bug with the original `break` -- it broke the for loop instead the outer loop. This is now fixed with loop labels.

Apart from fixing the behavior, after this modification, resender keeps running even if errors channel is closed as long as usender is still running. Until this change, users were force to a) keep the channel to avoid its closure and b) receive messages from it so it doesn't get full. There are situations when the user is no longer interested in connection errors but still needs the networking stack to keep running. Now, it is possible to just drop the errors channel to get that effect.