### PR TITLE
de_net: Improve task termination & logs

### DIFF
--- a/crates/net/src/tasks/dreceiver.rs
+++ b/crates/net/src/tasks/dreceiver.rs
@@ -34,7 +34,12 @@ pub(super) async fn run(
     let mut buffer = [0u8; MAX_DATAGRAM_SIZE];
 
     loop {
-        if system_datagrams.is_closed() || user_datagrams.is_closed() {
+        if user_datagrams.is_closed() {
+            break;
+        }
+
+        if system_datagrams.is_closed() {
+            error!("System message receiver channel on port {port} is unexpectedly closed.");
             break;
         }
 

--- a/crates/net/src/tasks/ureceiver.rs
+++ b/crates/net/src/tasks/ureceiver.rs
@@ -34,7 +34,7 @@ pub(super) async fn run(
         };
 
         let Ok(datagram) = result else {
-            error!("Datagram input channel is unexpectedly closed.");
+            error!("Datagram receiver channel is unexpectedly closed.");
             break;
         };
 

--- a/crates/net/src/tasks/usender.rs
+++ b/crates/net/src/tasks/usender.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use async_std::channel::{Receiver, Sender};
-use tracing::info;
+use tracing::{error, info};
 
 use super::{cancellation::CancellationSender, dsender::OutDatagram};
 use crate::{
@@ -53,6 +53,7 @@ pub(super) async fn run(
             .is_err();
 
         if closed {
+            error!("Datagram sender channel on port {port} is unexpectedly closed. ");
             break;
         }
     }


### PR DESCRIPTION
Log an error when any task (channel) terminates at a point when it is not expected. Termination should propagate from closures of the public channels (`MessageSender`, `MessageReceiver` and `ConnErrorReceiver`) to the more distant parts of the networking stack.