### PR TITLE
de_net: Change MAX_DATAGRAM_SIZE

### DIFF
--- a/crates/net/src/net.rs
+++ b/crates/net/src/net.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 /// This is the maximum datagram size "guaranteed" to be deliverable over any
 /// reasonable network.
 ///
-/// https://stackoverflow.com/a/35697810/4448708
+/// <https://stackoverflow.com/a/35697810/4448708>
 pub const MAX_DATAGRAM_SIZE: usize = 508;
 
 /// This struct represents a low level network connection. The connection is

--- a/crates/net/src/net.rs
+++ b/crates/net/src/net.rs
@@ -8,9 +8,11 @@ use thiserror::Error;
 
 /// Maximum size of a UDP datagram which might be sent by this crate.
 ///
-/// For the sake of simplicity, this is currently a value smaller than any
-/// widely used MTU.
-pub const MAX_DATAGRAM_SIZE: usize = 512;
+/// This is the maximum datagram size "guaranteed" to be deliverable over any
+/// reasonable network.
+///
+/// https://stackoverflow.com/a/35697810/4448708
+pub const MAX_DATAGRAM_SIZE: usize = 508;
 
 /// This struct represents a low level network connection. The connection is
 /// based on UDP and is unreliable and unordered.


### PR DESCRIPTION
# Quote from https://stackoverflow.com/a/35697810/4448708:

The maximum safe UDP payload is 508 bytes. This is a packet size of 576 (the "minimum maximum reassembly buffer size"), minus the maximum 60-byte IP header and the 8-byte UDP header.

Any UDP payload this size or smaller is guaranteed to be deliverable over IP (though not guaranteed to be delivered). Anything larger is allowed to be outright dropped by any router for any reason. Except on an IPv6-only route, where the maximum payload is 1,212 bytes. As others have mentioned, additional protocol headers could be added in some circumstances. A more conservative value of around 300-400 bytes may be preferred instead.

The maximum possible UDP payload is 67 KB, split into 45 IP packets, adding an additional 900 bytes of overhead (IPv4, MTU 1500, minimal 20-byte IP headers).

Any UDP packet may be fragmented. But this isn't too important, because losing a fragment has the same effect as losing an unfragmented packet: the entire packet is dropped. With UDP, this is going to happen either way.

# Quote from RFC 1122 (https://www.rfc-editor.org/rfc/rfc1122):

We designate the largest datagram size that can be reassembled by EMTU_R ("Effective MTU to receive"); this is sometimes called the "reassembly buffer size".  EMTU_R MUST be greater than or equal to 576, SHOULD be either configurable or indefinite, and SHOULD be greater than or equal to the MTU of the connected network(s).

# Another quote from RFC 1122:

Since nearly all networks in the Internet currently support an MTU of 576 or greater, we strongly recommend the use of 576 for datagrams sent to non-local networks.

# Quote from RFC 791 (https://www.rfc-editor.org/rfc/rfc791):

IHL: 4 bits

Internet Header Length is the length of the internet header in 32 bit words, and thus points to the beginning of the data. Note that the minimum value for a correct header is 5.
