### PR TITLE
de_net: Change sreceiver cancellation mode

### DIFF
--- a/crates/net/src/tasks/dreceiver.rs
+++ b/crates/net/src/tasks/dreceiver.rs
@@ -34,12 +34,7 @@ pub(super) async fn run(
     let mut buffer = [0u8; MAX_DATAGRAM_SIZE];
 
     loop {
-        if user_datagrams.is_closed() {
-            break;
-        }
-
-        if system_datagrams.is_closed() {
-            error!("System message receiver channel on port {port} is unexpectedly closed.");
+        if user_datagrams.is_closed() || system_datagrams.is_closed() {
             break;
         }
 

--- a/crates/net/src/tasks/mod.rs
+++ b/crates/net/src/tasks/mod.rs
@@ -46,8 +46,10 @@ pub fn startup(
     ));
 
     let resends = Resends::new();
+    let (sreceiver_cancellation_sender, sreceiver_cancellation_receiver) = cancellation();
     task::spawn(sreceiver::run(
         port,
+        sreceiver_cancellation_receiver,
         in_system_datagrams_receiver,
         resends.clone(),
     ));
@@ -69,6 +71,7 @@ pub fn startup(
     task::spawn(resender::run(
         port,
         resender_cancellation_receiver,
+        sreceiver_cancellation_sender,
         out_datagrams_sender.clone(),
         errors_sender,
         resends.clone(),


### PR DESCRIPTION
It is desirable that system datagram receiver (`sreceiver`) keeps processing system datagrams (e.g. confirmations) until `resender` finishes. Otherwise, `resender` would keep resending and failing messages because there would be no means of datagram confirmation.