### PR TITLE
Remove obsoleted .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/themes/book"]
-	path = docs/themes/book
-	url = https://github.com/getzola/book.git


### PR DESCRIPTION
The submodule is no longer used. Should have been done as part of #542.