### PR TITLE
Fix config defualts

### DIFF
--- a/crates/conf/src/conf.rs
+++ b/crates/conf/src/conf.rs
@@ -72,8 +72,8 @@ impl Default for Camera {
             min_distance: 20.,
             max_distance: 80.,
             wheel_zoom_sensitivity: 1.1,
-            touchpad_zoom_sensitivity: 1.1,
-            rotation_sensitivity: 0.01,
+            touchpad_zoom_sensitivity: 1.01,
+            rotation_sensitivity: 0.008,
             scroll_inverted: false,
         }
     }


### PR DESCRIPTION
Change config defaults to match docs. This was broken by mistake in #453.

This showcases why using #537 to generate the docs instead of doing it manually would be helpful and eliminate human error.