### PR TITLE
CI: Forbid TODO comments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,3 +108,11 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo-udeps
         run: cargo udeps
+
+  comments:
+    name: Check Code Comments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Forgotten TODOs
+        run: bash tools/todos.sh

--- a/tools/todos.sh
+++ b/tools/todos.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+git grep -n '//\s*TODO' -- '*.rs'
+exit_status=$?
+
+if [ $exit_status -eq 0 ]; then
+    exit 1
+elif [ $exit_status -eq 1 ]; then
+    exit 0
+else
+    exit $exit_status
+fi


### PR DESCRIPTION
Make sure that now TODO comments are left in production code so that situations like #580 do not happen again.