### PR TITLE
de_connector: Ignore message from non-participants

### DIFF
--- a/crates/connector/src/game/greceiver.rs
+++ b/crates/connector/src/game/greceiver.rs
@@ -112,7 +112,7 @@ impl GameProcessor {
     /// Returns true if the massage should be ignored and further handles such
     /// messages.
     async fn handle_ignore(&self, message: &ToGameMessage) -> bool {
-        if !matches!(message.message, ToGame::Join | ToGame::Leave) {
+        if matches!(message.message, ToGame::Join | ToGame::Leave) {
             // Join must be excluded from the condition because of the
             // chicken and egg problem.
             //

--- a/crates/connector/tests/integration.rs
+++ b/crates/connector/tests/integration.rs
@@ -109,8 +109,8 @@ fn test() {
         received.load(&mut client, &mut buffer).await;
         received.load(&mut client, &mut buffer).await;
 
-        // [3, 1] -> FromGame::PeerJoined(1)
-        let id = received.find_id(true, &[3, 1]).unwrap().to_be_bytes();
+        // [4, 1] -> FromGame::PeerJoined(1)
+        let id = received.find_id(true, &[4, 1]).unwrap().to_be_bytes();
         // And send a confirmation
         client
             .send(server, &[128, 0, 0, 0, id[1], id[2], id[3]])
@@ -291,8 +291,8 @@ async fn create_game() -> (Socket, u16) {
     let mut received = ReceivedBuffer::new();
     received.load(&mut client, &mut buffer).await;
 
-    // [1, 0] -> FromGame::Joined(0)
-    let id = received.find_id(true, &[1, 0]).unwrap().to_be_bytes();
+    // [2, 0] -> FromGame::Joined(0)
+    let id = received.find_id(true, &[2, 0]).unwrap().to_be_bytes();
     client
         .send(server, &[128, 0, 0, 0, id[1], id[2], id[3]])
         .await
@@ -317,8 +317,8 @@ async fn join_game(game_port: u16) -> Socket {
     received.load(&mut client, &mut buffer).await;
     received.assert_confirmed(3);
 
-    // [1, 1] -> FromGame::Joined(1)
-    let id = received.find_id(true, &[1, 1]).unwrap().to_be_bytes();
+    // [2, 1] -> FromGame::Joined(1)
+    let id = received.find_id(true, &[2, 1]).unwrap().to_be_bytes();
     client
         .send(server, &[128, 0, 0, 0, id[1], id[2], id[3]])
         .await

--- a/crates/net/src/messages.rs
+++ b/crates/net/src/messages.rs
@@ -44,6 +44,9 @@ pub enum ToGame {
 pub enum FromGame {
     /// Response to [`ToGame::Ping`].
     Pong(u32),
+    /// Informs the player that the server has discarded one or more incoming
+    /// messages (to any peer) due to the player not being part of the game.
+    NotJoined,
     /// Informs the player that they were just connected to the game under the
     /// ID.
     Joined(u8),


### PR DESCRIPTION
The main reason to ignore such messages is the case of a network issue (from server to client). The affected player is automatically kicked from the game in such a case. However, the client may not detect the network issue (e.g. because there was no traffic from the client to the server at the moment), therefore it may continue sending data to the game. Such a state might lead to issues within other game participants (e.g. receiving game sync messages from a unknown player).

Apart from the reason above, this is also a step towards better security. However it won't suffice on its own.

Fixes #583.