### PR TITLE
de_connector: Start player numbering with 1

### DIFF
--- a/crates/connector/src/game/state.rs
+++ b/crates/connector/src/game/state.rs
@@ -58,7 +58,7 @@ struct GameStateInner {
 impl GameStateInner {
     fn new(max_players: u8) -> Self {
         Self {
-            available_ids: Vec::from_iter((0..max_players).rev()),
+            available_ids: Vec::from_iter((1..=max_players).rev()),
             players: AHashMap::new(),
         }
     }

--- a/crates/connector/tests/integration.rs
+++ b/crates/connector/tests/integration.rs
@@ -109,8 +109,8 @@ fn test() {
         received.load(&mut client, &mut buffer).await;
         received.load(&mut client, &mut buffer).await;
 
-        // [5, 1] -> FromGame::PeerJoined(1)
-        let id = received.find_id(true, &[5, 1]).unwrap().to_be_bytes();
+        // [5, 2] -> FromGame::PeerJoined(1)
+        let id = received.find_id(true, &[5, 2]).unwrap().to_be_bytes();
         // And send a confirmation
         client
             .send(server, &[128, 0, 0, 0, id[1], id[2], id[3]])
@@ -291,8 +291,8 @@ async fn create_game() -> (Socket, u16) {
     let mut received = ReceivedBuffer::new();
     received.load(&mut client, &mut buffer).await;
 
-    // [2, 0] -> FromGame::Joined(0)
-    let id = received.find_id(true, &[2, 0]).unwrap().to_be_bytes();
+    // [2, 1] -> FromGame::Joined(1)
+    let id = received.find_id(true, &[2, 1]).unwrap().to_be_bytes();
     client
         .send(server, &[128, 0, 0, 0, id[1], id[2], id[3]])
         .await
@@ -317,8 +317,8 @@ async fn join_game(game_port: u16) -> Socket {
     received.load(&mut client, &mut buffer).await;
     received.assert_confirmed(3);
 
-    // [2, 1] -> FromGame::Joined(1)
-    let id = received.find_id(true, &[2, 1]).unwrap().to_be_bytes();
+    // [2, 2] -> FromGame::Joined(2)
+    let id = received.find_id(true, &[2, 2]).unwrap().to_be_bytes();
     client
         .send(server, &[128, 0, 0, 0, id[1], id[2], id[3]])
         .await

--- a/crates/net/src/messages.rs
+++ b/crates/net/src/messages.rs
@@ -40,6 +40,10 @@ pub enum ToGame {
 
 /// Message to be sent from a game server to a player/client (inside of a
 /// game).
+///
+/// # Notes
+///
+/// * Players are numbered from 1 to `max_players` (inclusive).
 #[derive(Encode, Decode)]
 pub enum FromGame {
     /// Response to [`ToGame::Ping`].


### PR DESCRIPTION
This makes it compatible with `de_core::player::Player`. Numbering from 1 was chosen so that it is more user friendly.