### PR TITLE
de_net: Separate (non)reliable datagram counters

### DIFF
--- a/docs/src/multiplayer/connector/protocol.md
+++ b/docs/src/multiplayer/connector/protocol.md
@@ -23,7 +23,8 @@ by the mask `0b1000_0000`).
 
 Each user package has an ID, encoded within the last three bytes of the
 datagram header. These IDs increment until they reach the maximum value that
-can be encoded within three bytes, after which the counter resets to 0.
+can be encoded within three bytes, after which the counter resets to 0. The ID
+sequence for reliable and unreliable packages are independent.
 
 Packages can be transmitted in either reliable or non-reliable mode.
 Reliability is signaled by the second highest bit of the flags byte


### PR DESCRIPTION
This will simplify reliable datagram deduplication because it could be assumed that there is only a small number of holes before the highest received ID.