### PR TITLE
de_net: Deduplicate reliable packages

### DIFF
--- a/crates/connector/tests/integration.rs
+++ b/crates/connector/tests/integration.rs
@@ -121,12 +121,15 @@ fn test() {
 
         let mut data = [22; 412];
         data[0] = 64; // Reliable
+        data[1] = 0;
+        data[2] = 0;
+        data[3] = 22;
         client.send(server, &data).await.unwrap();
 
         let mut received = ReceivedBuffer::new();
         received.load(&mut client, &mut buffer).await;
         received.load(&mut client, &mut buffer).await;
-        received.assert_confirmed(1447446);
+        received.assert_confirmed(22);
         received.find_id(false, &[82, 83, 84]).unwrap();
 
         // Try to send invalid data -- wrong header
@@ -177,14 +180,14 @@ fn test() {
 
         client
             // Reliable
-            .send(server, &[64, 0, 8, 7, 5, 6, 7, 8])
+            .send(server, &[64, 0, 0, 14, 5, 6, 7, 8])
             .await
             .unwrap();
 
         let mut received = ReceivedBuffer::new();
         received.load(&mut client, &mut buffer).await;
         received.load(&mut client, &mut buffer).await;
-        received.assert_confirmed(2055);
+        received.assert_confirmed(14);
         let id = received.find_id(true, &[22; 408]).unwrap().to_be_bytes();
         // Sending confirmation
 

--- a/crates/net/src/connection/book.rs
+++ b/crates/net/src/connection/book.rs
@@ -6,7 +6,7 @@ use std::{
 use ahash::AHashMap;
 
 /// Connection info should be tossed away after this time.
-const MAX_CONN_AGE: Duration = Duration::from_secs(600);
+pub(crate) const MAX_CONN_AGE: Duration = Duration::from_secs(600);
 
 pub(super) trait Connection {
     /// Returns true if the value holds any pending actions on the connection.

--- a/crates/net/src/connection/resend.rs
+++ b/crates/net/src/connection/resend.rs
@@ -12,7 +12,7 @@ use async_std::{
 use priority_queue::PriorityQueue;
 
 use super::{
-    book::{Connection, ConnectionBook},
+    book::{Connection, ConnectionBook, MAX_CONN_AGE},
     databuf::DataBuf,
 };
 use crate::{
@@ -22,6 +22,7 @@ use crate::{
 
 const START_BACKOFF_MS: u64 = 220;
 const MAX_TRIES: u8 = 6;
+const MAX_BASE_RESEND_INTERVAL_MS: u64 = (MAX_CONN_AGE.as_millis() / 2) as u64;
 
 #[derive(Clone)]
 pub(crate) struct Resends {
@@ -269,7 +270,7 @@ impl Timing {
     }
 
     fn backoff(attempt: u8) -> u64 {
-        START_BACKOFF_MS * 2u64.pow(attempt as u32)
+        MAX_BASE_RESEND_INTERVAL_MS.min(START_BACKOFF_MS * 2u64.pow(attempt as u32))
     }
 
     fn jitter(millis: u64) -> u64 {

--- a/docs/src/multiplayer/connector/protocol.md
+++ b/docs/src/multiplayer/connector/protocol.md
@@ -31,7 +31,7 @@ Reliability is signaled by the second highest bit of the flags byte
 (represented by the mask `0b0100_0000`). Packages sent in reliable mode always
 receive confirmation from the receiving party and are retransmitted multiple
 times, with the time delay exponentially increasing until a confirmation is
-obtained.
+obtained. Reliably sent packages are automatically deduplicated.
 
 Packages can be targeted to the server. This is signaled by the third highest
 bit of the flags byte (represented by the mask `0b0010_0000`). All other


### PR DESCRIPTION
It is proving hard to solve possible redundancies at all places where it matters. This solves this issue once for all for reliable packages.