### PR TITLE
Multiplayer: better join/open-game errors

### DIFF
--- a/crates/connector/src/game/greceiver.rs
+++ b/crates/connector/src/game/greceiver.rs
@@ -167,7 +167,9 @@ impl GameProcessor {
     /// Process connect message.
     async fn process_join(&mut self, meta: MessageMeta) {
         if let Err(err) = self.clients.reserve(meta.source).await {
-            warn!("Ignoring Join request: {err}");
+            warn!("Join request error: {err}");
+            self.send(&FromGame::JoinError(JoinError::DifferentGame), meta.source)
+                .await;
             return;
         }
 
@@ -184,6 +186,9 @@ impl GameProcessor {
                             "Player {:?} has already joined game on port {}.",
                             meta.source, self.port
                         );
+
+                        self.send(&FromGame::JoinError(JoinError::AlreadyJoined), meta.source)
+                            .await;
                     }
                     JoinErrorInner::GameFull => {
                         warn!(

--- a/crates/connector/src/server.rs
+++ b/crates/connector/src/server.rs
@@ -3,8 +3,8 @@ use std::net::SocketAddr;
 use anyhow::Context;
 use async_std::task;
 use de_net::{
-    self, FromServer, MessageDecoder, OutPackage, PackageReceiver, PackageSender, Peers, Socket,
-    ToServer,
+    self, FromServer, GameOpenError, MessageDecoder, OutPackage, PackageReceiver, PackageSender,
+    Peers, Socket, ToServer,
 };
 use tracing::{error, info, warn};
 
@@ -75,7 +75,12 @@ impl MainServer {
 
     async fn open_game(&mut self, source: SocketAddr, max_players: u8) -> anyhow::Result<()> {
         if let Err(err) = self.clients.reserve(source).await {
-            warn!("Ignoring OpenGame request: {err}");
+            warn!("OpenGame request error: {err}");
+            self.reply(
+                &FromServer::GameOpenError(GameOpenError::DifferentGame),
+                source,
+            )
+            .await?;
             return Ok(());
         }
 

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -1,5 +1,5 @@
 pub use header::Peers;
-pub use messages::{FromGame, FromServer, JoinError, ToGame, ToServer};
+pub use messages::{FromGame, FromServer, GameOpenError, JoinError, ToGame, ToServer};
 pub use protocol::{Targets, MAX_PACKAGE_SIZE};
 pub use socket::{RecvError, SendError, Socket, MAX_DATAGRAM_SIZE};
 pub use tasks::{

--- a/crates/net/src/messages.rs
+++ b/crates/net/src/messages.rs
@@ -22,6 +22,13 @@ pub enum FromServer {
         /// Port at which players may connect to join the game.
         port: u16,
     },
+    GameOpenError(GameOpenError),
+}
+
+#[derive(Encode, Decode)]
+pub enum GameOpenError {
+    /// The player opening the game has already joined a different game.
+    DifferentGame,
 }
 
 /// Message to be sent from a player/client to a game server (inside of a
@@ -71,4 +78,8 @@ pub enum FromGame {
 #[derive(Encode, Decode)]
 pub enum JoinError {
     GameFull,
+    /// The player has already joined the game.
+    AlreadyJoined,
+    /// The player already participates on a different game.
+    DifferentGame,
 }


### PR DESCRIPTION
Since PR #605 no reliable packages are duplicated, therefore the only reason behind a player joining / opening multiple games at the same time is an error on client side. This exposes and handles the error.