### PR TITLE
Fix new Clippy lints

### DIFF
--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -17,7 +17,7 @@ pub struct ResendEventPlugin<T: Event> {
 impl<T: Event> Default for ResendEventPlugin<T> {
     fn default() -> Self {
         Self {
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 }

--- a/crates/movement/src/cache.rs
+++ b/crates/movement/src/cache.rs
@@ -57,7 +57,7 @@ impl<M> Default for DecayingCache<M> {
         DecayingCache {
             entities: Vec::new(),
             capacity: 0.,
-            _m: PhantomData::default(),
+            _m: PhantomData,
         }
     }
 }

--- a/crates/net/src/tasks/communicator.rs
+++ b/crates/net/src/tasks/communicator.rs
@@ -191,7 +191,7 @@ impl InPackage {
         MessageDecoder {
             data: self.data.as_slice(),
             offset: 0,
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 

--- a/crates/terrain/src/shader.rs
+++ b/crates/terrain/src/shader.rs
@@ -150,8 +150,7 @@ impl KdTree {
             range: 0..circles.len(),
         }];
 
-        while !stack.is_empty() {
-            let item = stack.pop().unwrap();
+        while let Some(item) = stack.pop() {
             let subtree = &mut circles[item.range.clone()];
 
             subtree.sort_by(|a, b| {

--- a/crates/tools/src/bounds.rs
+++ b/crates/tools/src/bounds.rs
@@ -42,8 +42,7 @@ pub fn execute(path: &Path) {
         let mut stack = Vec::new();
         stack.extend(scene.nodes().map(WorldNode::from_node));
 
-        while !stack.is_empty() {
-            let world_node = stack.pop().unwrap();
+        while let Some(world_node) = stack.pop() {
             let node = world_node.node();
 
             stack.extend(node.children().map(|c| world_node.new_child(c)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
                 wait_duration: Duration::from_secs(10),
                 filter: None,
             })
-            .add_plugin(FrameTimeDiagnosticsPlugin::default())
+            .add_plugin(FrameTimeDiagnosticsPlugin)
             .add_plugin(GamePlugin)
             .add_plugins(ConfigPluginGroup)
             .add_plugins(GuiPluginGroup)


### PR DESCRIPTION
This fixes new lints added to Clippy released with Rust 1.71:

* default_constructed_unit_structs
* manual_while_let_some