### PR TITLE
Conf: Make DE Connector address configurable

### DIFF
--- a/crates/conf/src/conf.rs
+++ b/crates/conf/src/conf.rs
@@ -2,6 +2,8 @@
 //! This module implements final (i.e. parsed and validated) game configuration
 //! objects and their building from persistent configuration.
 
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use anyhow::{ensure, Context, Error, Result};
 use async_std::path::Path;
 use conf_macros::Config;
@@ -17,8 +19,9 @@ use crate::bundle_config;
 
 #[derive(Deserialize, Serialize, Config, Debug, Clone)]
 pub struct MultiplayerConf {
-    #[ensure(server.scheme() == "http", "Only `http` scheme is allowed for `server`.")]
-    server: Url,
+    #[ensure(lobby.scheme() == "http", "Only `http` scheme is allowed for `lobby`.")]
+    lobby: Url,
+    connector: SocketAddr,
 }
 
 #[derive(Deserialize, Serialize, Config, Debug, Clone)]
@@ -60,7 +63,8 @@ pub struct AudioConf {
 impl Default for MultiplayerConf {
     fn default() -> Self {
         Self {
-            server: Url::parse("http://lobby.de_game.org").unwrap(),
+            lobby: Url::parse("http://lobby.de_game.org").unwrap(),
+            connector: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8082),
         }
     }
 }
@@ -163,8 +167,13 @@ impl CameraConf {
 
 impl MultiplayerConf {
     /// Server URL for lobby connections.
-    pub fn server(&self) -> &Url {
-        &self.server
+    pub fn lobby(&self) -> &Url {
+        &self.lobby
+    }
+
+    /// Socket address of a DE Connector main sever.
+    pub fn connector(&self) -> SocketAddr {
+        self.connector
     }
 }
 

--- a/crates/conf/src/io.rs
+++ b/crates/conf/src/io.rs
@@ -24,6 +24,8 @@ pub(crate) async fn load_conf_text(path: &Path) -> Result<Option<String>> {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv6Addr};
+
     use async_std::{path::PathBuf, task};
     use de_uom::Metre;
 
@@ -41,9 +43,14 @@ mod tests {
         let conf = task::block_on(Configuration::load(path.as_path())).unwrap();
 
         assert_eq!(
-            conf.multiplayer().server().as_str(),
+            conf.multiplayer().lobby().as_str(),
             "http://example.com/de/"
         );
+        assert_eq!(
+            conf.multiplayer().connector().ip(),
+            IpAddr::V6(Ipv6Addr::LOCALHOST)
+        );
+        assert_eq!(conf.multiplayer().connector().port(), 8083);
         assert_eq!(conf.camera().min_distance(), Metre::new(12.5));
         assert_eq!(conf.camera().max_distance(), Metre::new(250.));
     }

--- a/crates/conf/tests/conf.yaml
+++ b/crates/conf/tests/conf.yaml
@@ -1,5 +1,6 @@
 multiplayer: # test comment
-  server: http://example.com/de/
+  lobby: http://example.com/de/
+  connector: '[::1]:8083'
 camera:
   min_distance: 12.5
   max_distance: 250

--- a/crates/lobby_client/src/systems.rs
+++ b/crates/lobby_client/src/systems.rs
@@ -35,7 +35,7 @@ fn setup_client(
         return false.into();
     };
 
-    let client = LobbyClient::build(conf.multiplayer().server().clone());
+    let client = LobbyClient::build(conf.multiplayer().lobby().clone());
     commands.insert_resource(client);
     false.into()
 }

--- a/docs/src/conf.md
+++ b/docs/src/conf.md
@@ -18,7 +18,9 @@ Missing configuration YAML file is treated equally to an empty YAML file, id
 est as if all properties are missing.
 
 * `multiplayer` (object) – multiplayer and network configuration.
-  * `server` (string; default: `http://lobby.de-game.org`) – lobby server base URL.
+  * `lobby` (string; default: `http://lobby.de-game.org`) – lobby server base URL.
+  * `connector` (string; default: `127.0.0.1:8082`) – DE Connector main server
+    socket address. It must be valid IPv4 or IPv6 address.
 * `camera` (object) – in-game camera configuration.
   * `move_margin` (f32; default: `40.0`) – horizontal camera movement is
     initiated if mouse is withing this distance in logical pixels to a window


### PR DESCRIPTION
The address is needed to create a new game.

Note that during existing game joining, clients will fetch the **game** address from the lobby API.