### PR TITLE
Fix HUD/details text node size

### DIFF
--- a/crates/controller/src/hud/details.rs
+++ b/crates/controller/src/hud/details.rs
@@ -54,11 +54,8 @@ fn setup(mut commands: GuiCommands) {
     let details_text = commands
         .spawn_body_text(
             OuterStyle {
-                size: Size {
-                    width: Val::Percent(20.),
-                    height: Val::Percent(30.),
-                },
                 margin: UiRect::all(Val::Percent(5.)),
+                ..default()
             },
             "",
         )


### PR DESCRIPTION
The node was (20%, 30%) of the parent node (not the screen).