### PR TITLE
lobby_client: Improve scheduling

### DIFF
--- a/crates/lobby_client/src/plugin.rs
+++ b/crates/lobby_client/src/plugin.rs
@@ -20,8 +20,8 @@ impl<T: LobbyRequestCreator> Plugin for EndpointPlugin<T> {
         app.add_event::<RequestEvent<T>>()
             .add_event::<ResponseEvent<T>>()
             .init_resource::<PendingTasks<T>>()
-            .add_system(fire::<T>)
-            .add_system(poll::<T>);
+            .add_system(fire::<T>.in_base_set(CoreSet::PostUpdate))
+            .add_system(poll::<T>.in_base_set(CoreSet::PreUpdate));
     }
 }
 


### PR DESCRIPTION
Most of systems sending / receiving the events are executed during `Update` so this change reduces potential for one frame delays.