### PR TITLE
Improve toast event scheduling

### DIFF
--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -15,8 +15,8 @@ use text::TextPlugin;
 pub use text::TextProps;
 use textbox::TextBoxPlugin;
 pub use textbox::{TextBoxCommands, TextBoxQuery};
+pub use toast::ToastEvent;
 use toast::ToastPlugin;
-pub use toast::{ToastEvent, ToastSet};
 
 mod body_text;
 mod button;

--- a/crates/gui/src/toast.rs
+++ b/crates/gui/src/toast.rs
@@ -14,9 +14,14 @@ impl Plugin for ToastPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ToastQueue>()
             .add_event::<ToastEvent>()
-            .add_system(process_events.in_set(ToastSet::ProcessEvents))
+            .add_system(
+                process_events
+                    .in_base_set(CoreSet::PostUpdate)
+                    .in_set(ToastSet::ProcessEvents),
+            )
             .add_system(
                 spawn_and_despawn
+                    .in_base_set(CoreSet::PostUpdate)
                     .run_if(not(in_state(AppState::AppLoading)))
                     .after(ToastSet::ProcessEvents),
             );
@@ -24,7 +29,7 @@ impl Plugin for ToastPlugin {
 }
 
 #[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, SystemSet)]
-pub enum ToastSet {
+enum ToastSet {
     ProcessEvents,
 }
 

--- a/crates/gui/src/toast.rs
+++ b/crates/gui/src/toast.rs
@@ -34,8 +34,6 @@ enum ToastSet {
 }
 
 /// Send this event to briefly display a UI toast.
-///
-/// The events are processed by a system labeled [`ToastSet::ProcessEvents`].
 pub struct ToastEvent(String);
 
 impl ToastEvent {

--- a/crates/menu/src/gamelisting.rs
+++ b/crates/menu/src/gamelisting.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use bevy::{prelude::*, time::Stopwatch};
-use de_gui::{ButtonCommands, GuiCommands, LabelCommands, OuterStyle, ToastEvent, ToastSet};
+use de_gui::{ButtonCommands, GuiCommands, LabelCommands, OuterStyle, ToastEvent};
 use de_lobby_client::{ListGamesRequest, RequestEvent, ResponseEvent};
 use de_lobby_model::GamePartial;
 
@@ -16,11 +16,7 @@ impl Plugin for GameListingPlugin {
         app.add_system(setup.in_schedule(OnEnter(MenuState::GameListing)))
             .add_system(cleanup.in_schedule(OnExit(MenuState::GameListing)))
             .add_system(refresh_system.run_if(in_state(MenuState::GameListing)))
-            .add_system(
-                list_games_system
-                    .run_if(in_state(MenuState::GameListing))
-                    .before(ToastSet::ProcessEvents),
-            )
+            .add_system(list_games_system.run_if(in_state(MenuState::GameListing)))
             .add_system(button_system.run_if(in_state(MenuState::GameListing)));
     }
 }

--- a/crates/menu/src/signin.rs
+++ b/crates/menu/src/signin.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use de_gui::{
     ButtonCommands, GuiCommands, LabelCommands, OuterStyle, SetFocusEvent, TextBoxCommands,
-    TextBoxQuery, ToastEvent, ToastSet,
+    TextBoxQuery, ToastEvent,
 };
 use de_lobby_client::{Authentication, LobbyRequest, SignInRequest, SignUpRequest};
 use de_lobby_model::{User, UserWithPassword, UsernameAndPassword};
@@ -25,16 +25,8 @@ impl Plugin for SignInPlugin {
                     .run_if(resource_exists::<Inputs>())
                     .run_if(in_state(MenuState::SignIn)),
             )
-            .add_system(
-                response_system::<SignInRequest>
-                    .run_if(in_state(MenuState::SignIn))
-                    .before(ToastSet::ProcessEvents),
-            )
-            .add_system(
-                response_system::<SignUpRequest>
-                    .run_if(in_state(MenuState::SignIn))
-                    .before(ToastSet::ProcessEvents),
-            )
+            .add_system(response_system::<SignInRequest>.run_if(in_state(MenuState::SignIn)))
+            .add_system(response_system::<SignUpRequest>.run_if(in_state(MenuState::SignIn)))
             .add_system(auth_system.run_if(in_state(MenuState::SignIn)));
     }
 }


### PR DESCRIPTION
All toast events are sent from `Update` base set. This change removes the need to schedule the sending events `.before(ToastSet::ProcessEvents)` and reduces the opportunity for future one-frame-delay errors.