### PR TITLE
Improve shadows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "de_map",
  "de_terrain",
  "de_uom",
+ "iyes_progress",
  "parry3d",
 ]
 

--- a/crates/camera/Cargo.toml
+++ b/crates/camera/Cargo.toml
@@ -21,4 +21,5 @@ de_terrain.workspace = true
 
 # Other
 bevy.workspace = true
+iyes_progress.workspace = true
 parry3d.workspace = true

--- a/crates/loader/src/map.rs
+++ b/crates/loader/src/map.rs
@@ -1,10 +1,8 @@
 use bevy::{
-    pbr::CascadeShadowConfigBuilder,
     prelude::*,
     tasks::{IoTaskPool, Task},
 };
 use de_camera::MoveFocusEvent;
-use de_conf::Configuration;
 use de_core::{
     assets::asset_path,
     cleanup::DespawnOnGameExit,
@@ -64,7 +62,6 @@ fn spawn_map(
     mut commands: Commands,
     task: Option<ResMut<MapLoadingTask>>,
     mut move_focus_events: EventWriter<MoveFocusEvent>,
-    user_config: Res<Configuration>,
     game_config: Res<GameConfig>,
 ) -> Progress {
     let mut task = match task {
@@ -109,7 +106,7 @@ fn spawn_map(
         move_focus_events.send(MoveFocusEvent::new(focus));
     }
 
-    setup_light(&mut commands, user_config.as_ref());
+    setup_light(&mut commands);
     commands.spawn((
         TerrainBundle::flat(map.metadata().bounds()),
         DespawnOnGameExit,
@@ -145,7 +142,7 @@ fn spawn_map(
     true.into()
 }
 
-fn setup_light(commands: &mut Commands, conf: &Configuration) {
+fn setup_light(commands: &mut Commands) {
     commands.insert_resource(AmbientLight {
         color: Color::WHITE,
         brightness: 0.6,
@@ -153,14 +150,6 @@ fn setup_light(commands: &mut Commands, conf: &Configuration) {
 
     let mut transform = Transform::IDENTITY;
     transform.look_at(Vec3::new(1., -1., 0.), Vec3::new(1., 1., 0.));
-
-    let cascade_shadow_config = CascadeShadowConfigBuilder {
-        num_cascades: 5,
-        maximum_distance: 1000.,
-        first_cascade_far_bound: conf.camera().min_distance().inner() * 2.,
-        ..default()
-    }
-    .build();
 
     commands.spawn((
         DirectionalLightBundle {
@@ -170,7 +159,6 @@ fn setup_light(commands: &mut Commands, conf: &Configuration) {
                 shadows_enabled: true,
                 ..Default::default()
             },
-            cascade_shadow_config,
             transform,
             ..Default::default()
         },


### PR DESCRIPTION
This improves shadow quality because the cascade bounds are derived from camera distance from the terrain. Most objects are close to the terrain and the camera off nadir is limited, therefore majority of the shadows are in a limited distance range dependent on the camera to focus point distance.

Also, this change reduces number of cascades from 5 to 4, fixing this warning: `The number of cascades configured for a directional light exceeds the supported limit of 4.`

Fixes #574.