### PR TITLE
Fix NetGameConf & StartMultiplayerEvent

### DIFF
--- a/crates/menu/src/multiplayer/setup.rs
+++ b/crates/menu/src/multiplayer/setup.rs
@@ -4,7 +4,7 @@ use de_gui::ToastEvent;
 use de_lobby_client::CreateGameRequest;
 use de_lobby_model::{GameConfig, GameSetup};
 use de_multiplayer::{
-    GameOpenedEvent, NetGameConf, ServerPort, ShutdownMultiplayerEvent, StartMultiplayerEvent,
+    ConnectionType, GameOpenedEvent, NetGameConf, ShutdownMultiplayerEvent, StartMultiplayerEvent,
 };
 
 use super::{
@@ -84,9 +84,11 @@ fn setup_network(
 ) {
     let connector_conf = config.multiplayer().connector();
     let net_game_conf = NetGameConf::new(
-        game_config.0.max_players().try_into().unwrap(),
         connector_conf.ip(),
-        ServerPort::Main(connector_conf.port()),
+        ConnectionType::CreateGame {
+            port: connector_conf.port(),
+            max_players: game_config.0.max_players().try_into().unwrap(),
+        },
     );
     multiplayer.send(StartMultiplayerEvent::new(net_game_conf));
 }

--- a/crates/multiplayer/src/config.rs
+++ b/crates/multiplayer/src/config.rs
@@ -3,22 +3,16 @@ use std::net::IpAddr;
 use de_core::player::Player;
 
 pub struct NetGameConf {
-    max_players: Player,
     server_host: IpAddr,
-    server_port: ServerPort,
+    connection_type: ConnectionType,
 }
 
 impl NetGameConf {
-    pub fn new(max_players: Player, server_host: IpAddr, server_port: ServerPort) -> Self {
+    pub fn new(server_host: IpAddr, connection_type: ConnectionType) -> Self {
         Self {
-            max_players,
             server_host,
-            server_port,
+            connection_type,
         }
-    }
-
-    pub(crate) fn max_players(&self) -> Player {
-        self.max_players
     }
 
     /// Address of DE Connector server.
@@ -26,20 +20,26 @@ impl NetGameConf {
         self.server_host
     }
 
-    pub(crate) fn server_port(&self) -> ServerPort {
-        self.server_port
+    pub(crate) fn connection_type(&self) -> ConnectionType {
+        self.connection_type
     }
 }
 
+/// Type of to be established connection to DE Connector.
 #[derive(Clone, Copy)]
-pub enum ServerPort {
-    /// Port of a main server.
+pub enum ConnectionType {
+    /// Create a new game via the given main server.
     ///
     /// This is not a game server thus the client must open a new game via this
     /// main server.
-    Main(u16),
-    /// Port of an existing game server.
+    CreateGame {
+        /// Port of the main server.
+        port: u16,
+        /// Maximum number of players to be configured for the new game.
+        max_players: Player,
+    },
+    /// Join a game server at the given port.
     ///
     /// This is a game server with other players potentially already connected.
-    Game(u16),
+    JoinGame(u16),
 }

--- a/crates/multiplayer/src/game.rs
+++ b/crates/multiplayer/src/game.rs
@@ -5,13 +5,13 @@ use de_core::{player::Player, schedule::PreMovement};
 use de_net::{FromGame, FromServer, GameOpenError, JoinError, ToGame, ToServer};
 
 use crate::{
+    config::ConnectionType,
     lifecycle::{FatalErrorEvent, NetGameConfRes},
     messages::{
         FromGameServerEvent, FromMainServerEvent, MessagesSet, Ports, ToGameServerEvent,
         ToMainServerEvent,
     },
     netstate::NetState,
-    ServerPort,
 };
 
 pub(crate) struct GamePlugin;
@@ -58,17 +58,17 @@ fn open_or_join(
     mut main_server: EventWriter<ToMainServerEvent>,
     mut game_server: EventWriter<ToGameServerEvent<true>>,
 ) {
-    match conf.server_port() {
-        ServerPort::Main(_) => {
+    match conf.connection_type() {
+        ConnectionType::CreateGame { max_players, .. } => {
             info!("Sending a open-game request.");
             main_server.send(
                 ToServer::OpenGame {
-                    max_players: conf.max_players().to_num(),
+                    max_players: max_players.to_num(),
                 }
                 .into(),
             );
         }
-        ServerPort::Game(_) => {
+        ConnectionType::JoinGame(_) => {
             info!("Sending a join-game request.");
             game_server.send(ToGame::Join.into());
         }

--- a/crates/multiplayer/src/lib.rs
+++ b/crates/multiplayer/src/lib.rs
@@ -14,7 +14,7 @@ use messages::MessagesPlugin;
 use stats::StatsPlugin;
 
 pub use crate::{
-    config::{NetGameConf, ServerPort},
+    config::{ConnectionType, NetGameConf},
     game::GameOpenedEvent,
     lifecycle::{MultiplayerShuttingDownEvent, ShutdownMultiplayerEvent, StartMultiplayerEvent},
     netstate::NetState,


### PR DESCRIPTION
Previously, it was not possible to join an existing game without needlessly specifying maximum number of players (which had no effect).