### PR TITLE
Lobby: Make player ordinals client controlled

### DIFF
--- a/crates/lobby/src/auth/db.rs
+++ b/crates/lobby/src/auth/db.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use super::passwd::{DbPassword, MAX_PASS_HASH_LEN, MAX_PASS_SALT_LEN};
 use crate::{
     db::{FromRow, SQLITE_CONSTRAINT_PRIMARYKEY},
-    db_error,
+    db_error_code,
 };
 
 #[derive(Clone)]
@@ -48,7 +48,7 @@ impl Users {
             .execute(self.pool)
             .await;
 
-        db_error!(
+        db_error_code!(
             result,
             RegistrationError::UsernameTaken,
             SQLITE_CONSTRAINT_PRIMARYKEY

--- a/crates/lobby/src/db.rs
+++ b/crates/lobby/src/db.rs
@@ -1,17 +1,27 @@
 use sqlx::sqlite::SqliteRow;
 
 pub const SQLITE_CONSTRAINT_PRIMARYKEY: &str = "1555";
-pub const SQLITE_CONSTRAINT_UNIQUE: &str = "2067";
 pub const SQLITE_CONSTRAINT_FOREIGNKEY: &str = "787";
 
 #[macro_export]
-macro_rules! db_error {
+macro_rules! db_error_code {
     ($result:expr, $error:expr, $code:expr) => {
         if let Err(sqlx::Error::Database(ref error)) = $result {
             if let Some(code) = error.code() {
                 if code == $code {
                     return Err($error);
                 }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! db_error_message {
+    ($result:expr, $error:expr, $message:expr) => {
+        if let Err(sqlx::Error::Database(ref error)) = $result {
+            if error.message() == $message {
+                return Err($error);
             }
         }
     };

--- a/crates/lobby/src/games/db.rs
+++ b/crates/lobby/src/games/db.rs
@@ -2,8 +2,8 @@ use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
 use de_lobby_model::{
-    Game, GameConfig, GameListing, GameMap, GamePartial, GameSetup, MAP_HASH_LEN,
-    MAX_GAME_NAME_LEN, MAX_MAP_NAME_LEN, MAX_USERNAME_LEN,
+    Game, GameConfig, GameListing, GameMap, GamePartial, GamePlayer, GamePlayerInfo, GameSetup,
+    MAP_HASH_LEN, MAX_GAME_NAME_LEN, MAX_MAP_NAME_LEN, MAX_USERNAME_LEN,
 };
 use futures_util::TryStreamExt;
 use log::info;
@@ -85,7 +85,7 @@ impl Games {
         let setup = GameSetup::try_from_row(game_row)?;
 
         let mut players = Vec::new();
-        let mut player_rows = query("SELECT username FROM players WHERE game = ?;")
+        let mut player_rows = query("SELECT ordinal, username FROM players WHERE game = ?;")
             .bind(game)
             .fetch(self.pool);
 
@@ -94,8 +94,7 @@ impl Games {
             .await
             .context("Failed to retrieve game players from the DB")?
         {
-            let username: String = player_row.try_get("username")?;
-            players.push(username);
+            players.push(GamePlayer::try_from_row(player_row)?);
         }
 
         Ok(Some(Game::new(setup, players)))
@@ -140,31 +139,40 @@ impl Games {
         Ok(())
     }
 
-    pub(super) async fn add_player(&self, username: &str, game: &str) -> Result<(), AdditionError> {
-        Self::add_player_inner(self.pool, false, username, game).await
+    pub(super) async fn add_player(
+        &self,
+        player: &GamePlayer,
+        game: &str,
+    ) -> Result<(), AdditionError> {
+        Self::add_player_inner(self.pool, false, player, game).await
     }
 
     async fn add_player_inner<'c, E>(
         executor: E,
         author: bool,
-        username: &str,
+        player: &GamePlayer,
         game: &str,
     ) -> Result<(), AdditionError>
     where
         E: SqliteExecutor<'c>,
     {
-        let result = query("INSERT INTO players (author, username, game) VALUES (?, ?, ?);")
-            .bind(author)
-            .bind(username)
-            .bind(game)
-            .execute(executor)
-            .await;
+        let result =
+            query("INSERT INTO players (ordinal, author, username, game) VALUES (?, ?, ?, ?);")
+                .bind(player.info().ordinal())
+                .bind(author)
+                .bind(player.username())
+                .bind(game)
+                .execute(executor)
+                .await;
 
         db_error!(
             result,
             AdditionError::UserOrGameDoesNotExist,
             SQLITE_CONSTRAINT_FOREIGNKEY
         );
+
+        // TODO constraint unique second type
+
         db_error!(
             result,
             AdditionError::AlreadyInAGame,
@@ -281,6 +289,16 @@ pub(super) enum RemovalError {
     NotInTheGame,
     #[error("A database error encountered")]
     Database(#[source] sqlx::Error),
+}
+
+impl FromRow for GamePlayer {
+    type Error = anyhow::Error;
+
+    fn try_from_row(row: SqliteRow) -> Result<Self, Self::Error> {
+        let username: String = row.try_get("username")?;
+        let ordinal: u8 = row.try_get("ordinal")?;
+        Ok(Self::new(username, GamePlayerInfo::new(ordinal)))
+    }
 }
 
 impl FromRow for GameSetup {

--- a/crates/lobby/src/games/db.rs
+++ b/crates/lobby/src/games/db.rs
@@ -178,6 +178,7 @@ impl Games {
             AdditionError::OrdinalConflict,
             "UNIQUE constraint failed: players.game, players.ordinal"
         );
+        db_error_message!(result, AdditionError::OrdinalTooLarge, "TOO-LARGE-ORDINAL");
 
         result.map_err(AdditionError::Database)?;
 
@@ -278,6 +279,8 @@ pub(super) enum AdditionError {
     AlreadyInAGame,
     #[error("Another player already joined the game with the same ordinal")]
     OrdinalConflict,
+    #[error("Player ordinal is larger than maximum number of players in the game")]
+    OrdinalTooLarge,
     #[error("The user or the game does not exist")]
     UserOrGameDoesNotExist,
     #[error("A database error encountered")]

--- a/crates/lobby/src/games/endpoints.rs
+++ b/crates/lobby/src/games/endpoints.rs
@@ -80,7 +80,6 @@ async fn join(
 ) -> impl Responder {
     let name = path.into_inner();
 
-    // TODO error code for conflict
     // TODO error if ordinal >= max players
 
     let player = GamePlayer::new(claims.username().to_owned(), player_info.0);
@@ -89,6 +88,11 @@ async fn join(
         Err(AdditionError::AlreadyInAGame) => {
             warn!("Game joining error: a user is already in a different game.");
             HttpResponse::Forbidden().json("User is already in a different game.")
+        }
+        Err(AdditionError::OrdinalConflict) => {
+            warn!("Game joining error: player ordinal conflict.");
+            HttpResponse::Conflict()
+                .json("Another player has already joined the game under the given ordinal.")
         }
         Err(AdditionError::UserOrGameDoesNotExist) => {
             warn!("Game joining error: the game or the user does not exist");

--- a/crates/lobby/src/games/endpoints.rs
+++ b/crates/lobby/src/games/endpoints.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, post, put, web, HttpResponse, Responder};
-use de_lobby_model::{Game, GameSetup, Validatable};
+use de_lobby_model::{Game, GamePlayer, GamePlayerInfo, GameSetup, Validatable};
 use log::{error, warn};
 
 use super::db::{AdditionError, CreationError, Games, RemovalError};
@@ -76,10 +76,15 @@ async fn join(
     claims: web::ReqData<Claims>,
     games: web::Data<Games>,
     path: web::Path<String>,
+    player_info: web::Json<GamePlayerInfo>,
 ) -> impl Responder {
     let name = path.into_inner();
 
-    match games.add_player(claims.username(), name.as_str()).await {
+    // TODO error code for conflict
+    // TODO error if ordinal >= max players
+
+    let player = GamePlayer::new(claims.username().to_owned(), player_info.0);
+    match games.add_player(&player, name.as_str()).await {
         Ok(_) => HttpResponse::Ok().json(()),
         Err(AdditionError::AlreadyInAGame) => {
             warn!("Game joining error: a user is already in a different game.");

--- a/crates/lobby/src/games/init.sql
+++ b/crates/lobby/src/games/init.sql
@@ -22,3 +22,14 @@ CREATE TABLE IF NOT EXISTS players (
         ON UPDATE CASCADE
         ON DELETE CASCADE
 );
+
+
+CREATE TRIGGER IF NOT EXISTS check_ordinal
+BEFORE INSERT ON players
+FOR EACH ROW
+BEGIN
+    SELECT CASE
+        WHEN (SELECT max_players FROM games WHERE name = NEW.game) IS NOT NULL AND NEW.ordinal > (SELECT max_players FROM games WHERE name = NEW.game)
+        THEN RAISE(FAIL, 'TOO-LARGE-ORDINAL')
+    END;
+END;

--- a/crates/lobby/src/games/init.sql
+++ b/crates/lobby/src/games/init.sql
@@ -7,10 +7,12 @@ CREATE TABLE IF NOT EXISTS games (
 );
 
 CREATE TABLE IF NOT EXISTS players (
-    ordinal INTEGER PRIMARY KEY AUTOINCREMENT,
+    ordinal TINYINT NOT NULL,
     author BOOLEAN NOT NULL,
     username CHARACTER({username_len}) NOT NULL UNIQUE,
     game CHARACTER({game_name_len}) NOT NULL,
+
+    UNIQUE (game, ordinal),
 
     FOREIGN KEY(username) REFERENCES users(username)
         ON UPDATE CASCADE

--- a/crates/lobby/src/games/init.sql
+++ b/crates/lobby/src/games/init.sql
@@ -9,10 +9,11 @@ CREATE TABLE IF NOT EXISTS games (
 CREATE TABLE IF NOT EXISTS players (
     ordinal TINYINT NOT NULL,
     author BOOLEAN NOT NULL,
-    username CHARACTER({username_len}) NOT NULL UNIQUE,
+    username CHARACTER({username_len}) NOT NULL,
     game CHARACTER({game_name_len}) NOT NULL,
 
-    UNIQUE (game, ordinal),
+    CONSTRAINT username UNIQUE (username),
+    CONSTRAINT ordinal UNIQUE (game, ordinal),
 
     FOREIGN KEY(username) REFERENCES users(username)
         ON UPDATE CASCADE

--- a/crates/lobby_model/src/games.rs
+++ b/crates/lobby_model/src/games.rs
@@ -13,16 +13,17 @@ const MAX_PLAYERS: u8 = 4;
 #[serde(rename_all = "camelCase")]
 pub struct Game {
     setup: GameSetup,
-    players: Vec<String>,
+    players: Vec<GamePlayer>,
 }
 
 impl Game {
-    /// Creates a new game with the author being the only player.
+    /// Creates a new game with the author having ordinal number of 0 and being
+    /// the only player.
     pub fn from_author(setup: GameSetup, author: String) -> Self {
-        Self::new(setup, vec![author])
+        Self::new(setup, vec![GamePlayer::new(author, GamePlayerInfo::new(0))])
     }
 
-    pub fn new(setup: GameSetup, players: Vec<String>) -> Self {
+    pub fn new(setup: GameSetup, players: Vec<GamePlayer>) -> Self {
         Self { setup, players }
     }
 
@@ -30,8 +31,45 @@ impl Game {
         &self.setup
     }
 
-    pub fn players(&self) -> &[String] {
+    pub fn players(&self) -> &[GamePlayer] {
         self.players.as_slice()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GamePlayer {
+    username: String,
+    info: GamePlayerInfo,
+}
+
+impl GamePlayer {
+    pub fn new(username: String, info: GamePlayerInfo) -> Self {
+        Self { username, info }
+    }
+
+    pub fn username(&self) -> &str {
+        self.username.as_str()
+    }
+
+    pub fn info(&self) -> &GamePlayerInfo {
+        &self.info
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GamePlayerInfo {
+    ordinal: u8,
+}
+
+impl GamePlayerInfo {
+    pub fn new(ordinal: u8) -> Self {
+        Self { ordinal }
+    }
+
+    pub fn ordinal(&self) -> u8 {
+        self.ordinal
     }
 }
 

--- a/crates/lobby_model/src/games.rs
+++ b/crates/lobby_model/src/games.rs
@@ -17,10 +17,10 @@ pub struct Game {
 }
 
 impl Game {
-    /// Creates a new game with the author having ordinal number of 0 and being
+    /// Creates a new game with the author having ordinal number of 1 and being
     /// the only player.
     pub fn from_author(setup: GameSetup, author: String) -> Self {
-        Self::new(setup, vec![GamePlayer::new(author, GamePlayerInfo::new(0))])
+        Self::new(setup, vec![GamePlayer::new(author, GamePlayerInfo::new(1))])
     }
 
     pub fn new(setup: GameSetup, players: Vec<GamePlayer>) -> Self {
@@ -64,7 +64,11 @@ pub struct GamePlayerInfo {
 }
 
 impl GamePlayerInfo {
+    /// # Panics
+    ///
+    /// Panics if ordinal equal to 0 is used.
     pub fn new(ordinal: u8) -> Self {
+        assert!(ordinal > 0);
         Self { ordinal }
     }
 

--- a/crates/lobby_model/src/lib.rs
+++ b/crates/lobby_model/src/lib.rs
@@ -3,8 +3,8 @@ pub use auth::{
     MIN_PASSWORD_LEN,
 };
 pub use games::{
-    Game, GameConfig, GameListing, GameMap, GamePartial, GameSetup, MAP_HASH_LEN,
-    MAX_GAME_NAME_LEN, MAX_MAP_NAME_LEN,
+    Game, GameConfig, GameListing, GameMap, GamePartial, GamePlayer, GamePlayerInfo, GameSetup,
+    MAP_HASH_LEN, MAX_GAME_NAME_LEN, MAX_MAP_NAME_LEN,
 };
 pub use validation::Validatable;
 

--- a/docs/src/multiplayer/openapi.yaml
+++ b/docs/src/multiplayer/openapi.yaml
@@ -134,7 +134,15 @@ paths:
                   players:
                     type: array
                     items:
-                      type: string
+                      type: object
+                      properties:
+                        username:
+                          type: string
+                        info:
+                          type: object
+                          properties:
+                            ordinal:
+                              type: number
                   setup:
                     $ref: "#/components/schemas/game-setup"
         "404":
@@ -154,6 +162,20 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ordinal:
+                  type: integer
+                  minimum: 0
+                  description: >-
+                    Each player of the game has a unique number in the range
+                    from 0 to N, where N is the maximum allowed number of
+                    players in the game. This parameter sets the number for the
+                    joining player.
       responses:
         "200":
           description: The user successfully joined the game.
@@ -165,6 +187,9 @@ paths:
           description: The user is already part of a game.
         "404":
           description: The game does not exist.
+        "409":
+          description: >-
+            Another player with the same ordinal has already joined the game.
 
   /a/games/{name}/leave:
     put:

--- a/docs/src/multiplayer/openapi.yaml
+++ b/docs/src/multiplayer/openapi.yaml
@@ -170,10 +170,10 @@ paths:
               properties:
                 ordinal:
                   type: integer
-                  minimum: 0
+                  minimum: 1
                   description: >-
                     Each player of the game has a unique number in the range
-                    from 0 to N, where N is the maximum allowed number of
+                    from 1 to N, where N is the maximum allowed number of
                     players in the game. This parameter sets the number for the
                     joining player.
       responses:
@@ -189,7 +189,8 @@ paths:
           description: The game does not exist.
         "409":
           description: >-
-            Another player with the same ordinal has already joined the game.
+            The ordinal is too large or another player with the same ordinal
+            has already joined the game.
 
   /a/games/{name}/leave:
     put:


### PR DESCRIPTION
- Thanks to uniqueness constraint on the ordinal, this serves as a maximum number of players constraint.
- It delegates ordinal (player number) assignment to the client who already receives such info from DE Connector.

Fixes #308.