### PR TITLE
de_connector: Improve readiness staging

### DIFF
--- a/crates/multiplayer/src/game.rs
+++ b/crates/multiplayer/src/game.rs
@@ -189,13 +189,8 @@ fn process_from_game(
             FromGame::PeerLeft(id) => {
                 info!("Peer {id} left.");
             }
-            FromGame::Starting => {
-                info!("Multiplayer game is starting.");
-            }
-            FromGame::Started => {
-                fatals.send(FatalErrorEvent::new(
-                    "Multiplayer game is unexpectedly fully started.",
-                ));
+            FromGame::GameReadiness(readiness) => {
+                info!("Game readiness changed to: {readiness:?}");
             }
         }
     }

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -1,5 +1,5 @@
 pub use header::Peers;
-pub use messages::{FromGame, FromServer, GameOpenError, JoinError, ToGame, ToServer};
+pub use messages::{FromGame, FromServer, GameOpenError, JoinError, Readiness, ToGame, ToServer};
 pub use protocol::{Targets, MAX_PACKAGE_SIZE};
 pub use socket::{RecvError, SendError, Socket, MAX_DATAGRAM_SIZE};
 pub use tasks::{

--- a/crates/net/src/messages.rs
+++ b/crates/net/src/messages.rs
@@ -46,7 +46,7 @@ pub enum ToGame {
     /// Sets readiness of the client.
     ///
     /// New readiness must be greater by one or equal to the current readiness.
-    /// See [`Readiness::next`].
+    /// See [`Readiness::progress`].
     Readiness(Readiness),
 }
 

--- a/crates/net/src/messages.rs
+++ b/crates/net/src/messages.rs
@@ -43,11 +43,11 @@ pub enum ToGame {
     ///
     /// The game is automatically closed once all players disconnect.
     Leave,
-    /// This initiates game startup.
-    Start,
-    /// The game switches from starting state to started state once this
-    /// message is received from all players.
-    Initialized,
+    /// Sets readiness of the client.
+    ///
+    /// New readiness must be greater by one or equal to the current readiness.
+    /// See [`Readiness::next`].
+    Readiness(Readiness),
 }
 
 /// Message to be sent from a game server to a player/client (inside of a
@@ -78,12 +78,8 @@ pub enum FromGame {
     /// Informs the player that another player with the given ID just
     /// disconnected from the same game.
     PeerLeft(u8),
-    /// Informs the client that the game is starting. The game is no longer
-    /// available for joining. The client should start game initialization.
-    Starting,
-    /// Informs the client that the game fully started because all clients are
-    /// initiated.
-    Started,
+    /// Game readiness has changed.
+    GameReadiness(Readiness),
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -95,4 +91,49 @@ pub enum JoinError {
     AlreadyJoined,
     /// The player already participates on a different game.
     DifferentGame,
+}
+
+/// Readiness of an individual client or the game as a whole. It consists of a
+/// progression of individual variants / stages. Once all clients progress to a
+/// readiness stage, the game progresses to that stage as well.
+#[derive(Clone, Copy, Default, Debug, Encode, Decode, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Readiness {
+    /// Initial stage for all clients and the game.
+    #[default]
+    NotReady,
+    /// The client / game is ready for the game to start.
+    Ready,
+    /// The client / game is prepared for game initialization to begin.
+    Prepared,
+    /// The client / game is ready for the game to start.
+    ///
+    /// The actually game-play happens in this readiness stage.
+    Initialized,
+}
+
+impl Readiness {
+    pub fn progress(self) -> Option<Self> {
+        match self {
+            Self::NotReady => Some(Self::Ready),
+            Self::Ready => Some(Self::Prepared),
+            Self::Prepared => Some(Self::Initialized),
+            Self::Initialized => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_readiness() {
+        assert!(Readiness::default() < Readiness::Ready);
+        assert!(Readiness::NotReady < Readiness::Ready);
+        assert!(Readiness::Ready < Readiness::Prepared);
+        assert!(Readiness::Prepared < Readiness::Initialized);
+        assert!(Readiness::NotReady < Readiness::Initialized);
+
+        assert_eq!(Readiness::NotReady.progress().unwrap(), Readiness::Ready);
+    }
 }


### PR DESCRIPTION
- This makes it possible to wait a bit until all clients enter the game and become prepared to receive messages related to game initialization (like some kind of to be implemented map object spawn messages).
- It changes how the game is started -- all clients must be ready for that.
- All of that in a unified step-by-step progression of readiness stages.