### PR TITLE
Refactor plugin registration in multiplayer menu

### DIFF
--- a/crates/menu/src/multiplayer/joining.rs
+++ b/crates/menu/src/multiplayer/joining.rs
@@ -7,7 +7,7 @@ use de_multiplayer::{
 };
 
 use super::{
-    requests::{Receiver, RequestsPlugin, Sender},
+    requests::{Receiver, Sender},
     MultiplayerState,
 };
 use crate::MenuState;
@@ -16,26 +16,22 @@ pub(crate) struct JoiningGamePlugin;
 
 impl Plugin for JoiningGamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((
-            RequestsPlugin::<GetGameRequest>::new(),
-            RequestsPlugin::<JoinGameRequest>::new(),
-        ))
-        .add_event::<JoinGameEvent>()
-        .add_systems(OnEnter(MultiplayerState::GameJoining), get_game)
-        .add_systems(OnExit(MultiplayerState::GameJoining), cleanup)
-        .add_systems(
-            PreUpdate,
-            handle_join_event.run_if(in_state(MenuState::Multiplayer)),
-        )
-        .add_systems(
-            Update,
-            (
-                handle_get_response,
-                handle_joined_event.run_if(on_event::<GameJoinedEvent>()),
-                handle_join_response,
+        app.add_event::<JoinGameEvent>()
+            .add_systems(OnEnter(MultiplayerState::GameJoining), get_game)
+            .add_systems(OnExit(MultiplayerState::GameJoining), cleanup)
+            .add_systems(
+                PreUpdate,
+                handle_join_event.run_if(in_state(MenuState::Multiplayer)),
             )
-                .run_if(in_state(MultiplayerState::GameJoining)),
-        );
+            .add_systems(
+                Update,
+                (
+                    handle_get_response,
+                    handle_joined_event.run_if(on_event::<GameJoinedEvent>()),
+                    handle_join_response,
+                )
+                    .run_if(in_state(MultiplayerState::GameJoining)),
+            );
     }
 }
 

--- a/crates/menu/src/multiplayer/mod.rs
+++ b/crates/menu/src/multiplayer/mod.rs
@@ -1,10 +1,14 @@
 use bevy::prelude::*;
 use de_core::nested_state;
+use de_lobby_client::{
+    CreateGameRequest, GetGameRequest, JoinGameRequest, SignInRequest, SignUpRequest,
+};
 use de_multiplayer::MultiplayerShuttingDownEvent;
 
 use self::{
     create::CreateGamePlugin, gamelisting::GameListingPlugin, joined::JoinedGamePlugin,
-    joining::JoiningGamePlugin, setup::SetupGamePlugin, signin::SignInPlugin,
+    joining::JoiningGamePlugin, requests::RequestsPlugin, setup::SetupGamePlugin,
+    signin::SignInPlugin,
 };
 use crate::{menu::ScreenStatePlugin, MenuState};
 
@@ -21,6 +25,11 @@ pub(super) struct MultiplayerPlugin;
 impl Plugin for MultiplayerPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
+            RequestsPlugin::<SignInRequest>::new(),
+            RequestsPlugin::<SignUpRequest>::new(),
+            RequestsPlugin::<GetGameRequest>::new(),
+            RequestsPlugin::<CreateGameRequest>::new(),
+            RequestsPlugin::<JoinGameRequest>::new(),
             MultiplayerStatePlugin,
             ScreenStatePlugin::<MultiplayerState>::default(),
             SignInPlugin,

--- a/crates/menu/src/multiplayer/setup.rs
+++ b/crates/menu/src/multiplayer/setup.rs
@@ -8,7 +8,7 @@ use de_multiplayer::{
 };
 
 use super::{
-    requests::{Receiver, RequestsPlugin, Sender},
+    requests::{Receiver, Sender},
     MultiplayerState,
 };
 use crate::MenuState;
@@ -17,8 +17,7 @@ pub(crate) struct SetupGamePlugin;
 
 impl Plugin for SetupGamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(RequestsPlugin::<CreateGameRequest>::new())
-            .add_event::<SetupGameEvent>()
+        app.add_event::<SetupGameEvent>()
             .add_systems(OnEnter(MultiplayerState::GameSetup), setup_network)
             .add_systems(OnExit(MultiplayerState::GameSetup), cleanup)
             .add_systems(

--- a/crates/menu/src/multiplayer/signin.rs
+++ b/crates/menu/src/multiplayer/signin.rs
@@ -7,7 +7,7 @@ use de_lobby_client::{Authentication, LobbyRequest, SignInRequest, SignUpRequest
 use de_lobby_model::{User, UserWithPassword, UsernameAndPassword};
 
 use super::{
-    requests::{Receiver, RequestsPlugin, Sender},
+    requests::{Receiver, Sender},
     MultiplayerState,
 };
 use crate::menu::Menu;
@@ -16,22 +16,18 @@ pub(super) struct SignInPlugin;
 
 impl Plugin for SignInPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((
-            RequestsPlugin::<SignInRequest>::new(),
-            RequestsPlugin::<SignUpRequest>::new(),
-        ))
-        .add_systems(OnEnter(MultiplayerState::SignIn), setup)
-        .add_systems(OnExit(MultiplayerState::SignIn), cleanup)
-        .add_systems(
-            Update,
-            (
-                button_system.run_if(resource_exists::<Inputs>()),
-                response_system::<SignInRequest>,
-                response_system::<SignUpRequest>,
-                auth_system,
-            )
-                .run_if(in_state(MultiplayerState::SignIn)),
-        );
+        app.add_systems(OnEnter(MultiplayerState::SignIn), setup)
+            .add_systems(OnExit(MultiplayerState::SignIn), cleanup)
+            .add_systems(
+                Update,
+                (
+                    button_system.run_if(resource_exists::<Inputs>()),
+                    response_system::<SignInRequest>,
+                    response_system::<SignUpRequest>,
+                    auth_system,
+                )
+                    .run_if(in_state(MultiplayerState::SignIn)),
+            );
     }
 }
 


### PR DESCRIPTION
Previously, registration of different requests was scattered and might have led to duplicate plugin additions.