### PR TITLE
Refactor GameConfig & related

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,7 @@ dependencies = [
  "paste",
  "serde",
  "thiserror",
+ "tinyvec",
 ]
 
 [[package]]

--- a/crates/construction/src/manufacturing.rs
+++ b/crates/construction/src/manufacturing.rs
@@ -377,13 +377,10 @@ fn check_spawn_locations(
 
 fn produce(
     time: Res<Time>,
-    conf: Res<GameConfig>,
     counter: Res<ObjectCounter>,
     mut factories: Query<(Entity, &Player, &mut AssemblyLine)>,
     mut deliver_events: EventWriter<DeliverEvent>,
 ) {
-    let locals = conf.locals();
-
     let mut counts: AHashMap<Player, u32> = AHashMap::from_iter(
         counter
             .counters()
@@ -391,10 +388,6 @@ fn produce(
     );
 
     for (factory, &player, mut assembly) in factories.iter_mut() {
-        if !locals.is_local(player) {
-            continue;
-        }
-
         let player_count = counts.entry(player).or_default();
 
         loop {

--- a/crates/construction/src/manufacturing.rs
+++ b/crates/construction/src/manufacturing.rs
@@ -6,7 +6,6 @@ use de_audio::spatial::{PlaySpatialAudioEvent, Sound};
 use de_core::{
     cleanup::DespawnOnGameExit,
     gamestate::GameState,
-    gconfig::GameConfig,
     objects::{Active, ActiveObjectType, ObjectType, UnitType, PLAYER_MAX_UNITS},
     player::Player,
     projection::{ToAltitude, ToFlat},

--- a/crates/controller/src/commands/handlers.rs
+++ b/crates/controller/src/commands/handlers.rs
@@ -350,8 +350,7 @@ fn place_draft(
           mut events: EventWriter<NewDraftEvent>| {
         if counter
             .player(conf.locals().playable())
-            .unwrap()
-            .building_count()
+            .map_or(0, |c| c.building_count())
             >= PLAYER_MAX_BUILDINGS
         {
             warn!("Maximum number of buildings reached.");

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,3 +25,4 @@ parry3d.workspace = true
 paste.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+tinyvec.workspace = true

--- a/crates/core/src/player.rs
+++ b/crates/core/src/player.rs
@@ -4,8 +4,9 @@ use std::cmp::Ordering;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, Component, PartialEq, Eq, Hash)]
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, Component, PartialEq, Eq, Hash)]
 pub enum Player {
+    #[default]
     Player1,
     Player2,
     Player3,
@@ -13,7 +14,9 @@ pub enum Player {
 }
 
 impl Player {
-    pub fn to_num(self) -> u8 {
+    pub const MAX_PLAYERS: usize = 4;
+
+    pub const fn to_num(self) -> u8 {
         match self {
             Self::Player1 => 1,
             Self::Player2 => 2,

--- a/crates/core/src/player.rs
+++ b/crates/core/src/player.rs
@@ -16,7 +16,7 @@ pub enum Player {
 impl Player {
     pub const MAX_PLAYERS: usize = 4;
 
-    pub const fn to_num(self) -> u8 {
+    pub fn to_num(self) -> u8 {
         match self {
             Self::Player1 => 1,
             Self::Player2 => 2,

--- a/crates/loader/src/map.rs
+++ b/crates/loader/src/map.rs
@@ -112,12 +112,12 @@ fn spawn_map(
         DespawnOnGameExit,
     ));
 
-    let players = game_config.players();
+    let locals = game_config.locals();
     for object in map.content().objects() {
         let (mut entity_commands, object_type) = match object.inner() {
             InnerObject::Active(object) => {
                 let player = object.player();
-                if !players.contains(player) {
+                if !locals.is_local(player) {
                     continue;
                 }
 

--- a/crates/menu/src/singleplayer.rs
+++ b/crates/menu/src/singleplayer.rs
@@ -107,8 +107,7 @@ fn button_system(
                     Some(path) => {
                         commands.insert_resource(GameConfig::new(
                             path,
-                            Player::Player4,
-                            LocalPlayers::new(Player::Player1),
+                            LocalPlayers::from_max_player(Player::Player1, Player::Player4),
                         ));
                         next_state.set(AppState::InGame);
                     }

--- a/crates/spawner/src/counter.rs
+++ b/crates/spawner/src/counter.rs
@@ -1,13 +1,11 @@
-use std::ops::{Add, AddAssign};
+use std::{
+    collections::hash_map::Iter,
+    ops::{Add, AddAssign},
+};
 
 use ahash::AHashMap;
 use bevy::prelude::*;
-use de_core::{
-    gconfig::GameConfig,
-    objects::ActiveObjectType,
-    player::{Player, PlayerRange},
-    state::AppState,
-};
+use de_core::{objects::ActiveObjectType, player::Player, state::AppState};
 
 pub(crate) struct CounterPlugin;
 
@@ -24,20 +22,22 @@ pub struct ObjectCounter {
 }
 
 impl ObjectCounter {
-    fn new(players: PlayerRange) -> Self {
-        let mut map = AHashMap::with_capacity(players.len());
-        for player in players {
-            map.insert(player, PlayerObjectCounter::default());
+    fn new() -> Self {
+        Self {
+            players: AHashMap::new(),
         }
-        Self { players: map }
+    }
+
+    pub fn counters(&self) -> Iter<Player, PlayerObjectCounter> {
+        self.players.iter()
     }
 
     pub fn player(&self, player: Player) -> Option<&PlayerObjectCounter> {
         self.players.get(&player)
     }
 
-    pub(crate) fn player_mut(&mut self, player: Player) -> Option<&mut PlayerObjectCounter> {
-        self.players.get_mut(&player)
+    pub(crate) fn player_mut(&mut self, player: Player) -> &mut PlayerObjectCounter {
+        self.players.entry(player).or_default()
     }
 }
 
@@ -95,8 +95,8 @@ impl AddAssign<i32> for Count {
     }
 }
 
-fn setup(mut commands: Commands, config: Res<GameConfig>) {
-    commands.insert_resource(ObjectCounter::new(config.players()));
+fn setup(mut commands: Commands) {
+    commands.insert_resource(ObjectCounter::new());
 }
 
 fn cleanup(mut commands: Commands) {

--- a/crates/spawner/src/despawner.rs
+++ b/crates/spawner/src/despawner.rs
@@ -52,7 +52,7 @@ fn find_dead(
     for (entity, &player, &object_type, health, transform) in entities.iter() {
         if health.destroyed() {
             if let ObjectType::Active(active_type) = object_type {
-                counter.player_mut(player).unwrap().update(active_type, -1);
+                counter.player_mut(player).update(active_type, -1);
 
                 play_audio.send(PlaySpatialAudioEvent::new(
                     match active_type {

--- a/crates/spawner/src/gameend.rs
+++ b/crates/spawner/src/gameend.rs
@@ -21,11 +21,22 @@ fn game_end_detection_system(
     counter: Res<ObjectCounter>,
 ) {
     let mut result = None;
-    if counter.player(conf.locals().playable()).unwrap().total() == 0 {
+
+    let (playable, others) =
+        counter
+            .counters()
+            .fold((0, 0), |(playable, others), (&player, counter)| {
+                let total = counter.total();
+                if conf.locals().is_playable(player) {
+                    (playable + total, others)
+                } else {
+                    (playable, others + total)
+                }
+            });
+
+    if playable == 0 {
         result = Some(GameResult::finished(false));
-    } else if conf.players().all(|player| {
-        conf.locals().is_playable(player) || counter.player(player).unwrap().total() == 0
-    }) {
+    } else if others == 0 {
         result = Some(GameResult::finished(true));
     }
 

--- a/crates/spawner/src/spawner.rs
+++ b/crates/spawner/src/spawner.rs
@@ -71,7 +71,7 @@ fn spawn(
                 entity_commands.insert(Battery::default());
 
                 let player = *player.expect("Active object without an associated was spawned.");
-                counter.player_mut(player).unwrap().update(active_type, 1);
+                counter.player_mut(player).update(active_type, 1);
 
                 if game_config.locals().is_playable(player) || cfg!(feature = "godmode") {
                     entity_commands.insert(Playable);


### PR DESCRIPTION
This removes the need to configure max players for the game. It will not be possible to set the value for multiplayer games with sparse player numbering (e.g. only player 1, 3, 4 joining). 