### PR TITLE
Do not cache ~/.cargo/bin

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -55,7 +55,6 @@ runs:
       id: rust-cache
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/


### PR DESCRIPTION
Potentially fixes #685 (due to cached binary permissions).