### PR TITLE
de_net: Fix number of package resends

### DIFF
--- a/crates/net/src/connection/resend.rs
+++ b/crates/net/src/connection/resend.rs
@@ -253,10 +253,10 @@ impl Timing {
     }
 
     fn another(&self, now: Instant) -> Option<Self> {
-        if self.attempt == MAX_TRIES {
+        let attempt = self.attempt + 1;
+        if attempt == MAX_TRIES {
             None
         } else {
-            let attempt = self.attempt + 1;
             Some(Self {
                 attempt,
                 expiration: Self::schedule(attempt, now),


### PR DESCRIPTION
`MAX_TRIES` was used as if it was `MAX_RETRIES`.