### PR TITLE
de_net: Make package IDs separate for each connection

### DIFF
--- a/crates/connector/src/game/greceiver.rs
+++ b/crates/connector/src/game/greceiver.rs
@@ -5,7 +5,7 @@ use async_std::{
     task,
 };
 use de_messages::{FromGame, JoinError, Readiness, ToGame};
-use de_net::{OutPackage, Peers, Targets};
+use de_net::{OutPackage, Peers};
 use tracing::{error, info, warn};
 
 use super::state::{GameState, JoinError as JoinErrorInner};
@@ -274,18 +274,17 @@ impl GameProcessor {
     where
         E: bincode::Encode,
     {
-        if let Some(targets) = self.state.targets(exclude).await {
-            self.send(message, targets).await;
+        for target in self.state.targets(exclude).await {
+            self.send(message, target).await;
         }
     }
 
     /// Send message to some targets.
-    async fn send<E, T>(&self, message: &E, targets: T)
+    async fn send<E>(&self, message: &E, target: SocketAddr)
     where
         E: bincode::Encode,
-        T: Into<Targets<'static>>,
     {
-        let message = OutPackage::encode_single(message, true, Peers::Server, targets).unwrap();
+        let message = OutPackage::encode_single(message, true, Peers::Server, target).unwrap();
         let _ = self.outputs.send(message).await;
     }
 }

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -1,5 +1,5 @@
 pub use header::Peers;
-pub use protocol::{Targets, MAX_PACKAGE_SIZE};
+pub use protocol::MAX_PACKAGE_SIZE;
 pub use socket::{RecvError, SendError, Socket, MAX_DATAGRAM_SIZE};
 pub use tasks::{
     startup, ConnErrorReceiver, ConnectionError, InPackage, MessageDecoder, OutPackage,

--- a/crates/net/src/tasks/dsender.rs
+++ b/crates/net/src/tasks/dsender.rs
@@ -1,28 +1,22 @@
+use std::net::SocketAddr;
+
 use async_std::channel::Receiver;
 use tracing::{error, info};
 
-use crate::{
-    header::DatagramHeader,
-    protocol::{ProtocolSocket, Targets},
-    MAX_DATAGRAM_SIZE,
-};
+use crate::{header::DatagramHeader, protocol::ProtocolSocket, MAX_DATAGRAM_SIZE};
 
 pub(crate) struct OutDatagram {
     header: DatagramHeader,
     data: Vec<u8>,
-    targets: Targets<'static>,
+    target: SocketAddr,
 }
 
 impl OutDatagram {
-    pub(crate) fn new<T: Into<Targets<'static>>>(
-        header: DatagramHeader,
-        data: Vec<u8>,
-        targets: T,
-    ) -> Self {
+    pub(crate) fn new(header: DatagramHeader, data: Vec<u8>, target: SocketAddr) -> Self {
         Self {
             header,
             data,
-            targets: targets.into(),
+            target,
         }
     }
 }
@@ -40,7 +34,7 @@ pub(super) async fn run(port: u16, datagrams: Receiver<OutDatagram>, socket: Pro
                 &mut buffer,
                 datagram.header,
                 &datagram.data,
-                datagram.targets,
+                datagram.target,
             )
             .await
         {

--- a/docs/src/multiplayer/connector/protocol.md
+++ b/docs/src/multiplayer/connector/protocol.md
@@ -24,7 +24,8 @@ by the mask `0b1000_0000`).
 Each user package has an ID, encoded within the last three bytes of the
 datagram header. These IDs increment until they reach the maximum value that
 can be encoded within three bytes, after which the counter resets to 0. The ID
-sequence for reliable and unreliable packages are independent.
+sequence for reliable and unreliable packages are independent. Each connection
+/ client has independent reliable package numbering.
 
 Packages can be transmitted in either reliable or non-reliable mode.
 Reliability is signaled by the second highest bit of the flags byte


### PR DESCRIPTION
Continuous (per client) reliable message numbering is necessary for efficient out-of-order delivery detection, see ticket #700.

Packages to be delivered to multiple targets no longer share headers due the different package IDs. Therefore, the API for sending to multiple targets at once was removed.