### PR TITLE
Docs: Fix a link

### DIFF
--- a/docs/src/multiplayer/connector/encoding.md
+++ b/docs/src/multiplayer/connector/encoding.md
@@ -5,4 +5,4 @@ Individual messages, implemented as Rust enums, are encoded via
 messages are sent in a single [package](./protocol.md#package). Big endian with
 variable bit encoding is used.
 
-See individual message [documentation](/rust/de_net/protocol/).
+See individual message [documentation](/rust/de_messages/).


### PR DESCRIPTION
The message Rust objects were moved out to a different crate in 16469bf.