### PR TITLE
DE Lobby: Fix i9n tests

### DIFF
--- a/crates/connector/tests/common/mod.rs
+++ b/crates/connector/tests/common/mod.rs
@@ -13,7 +13,7 @@ use nix::{
 };
 
 pub fn spawn_and_wait() -> Child {
-    let mut command = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    let mut command = Command::cargo_bin("de-connector").unwrap();
 
     unsafe {
         command.pre_exec(|| {


### PR DESCRIPTION
Should have been done in 5d7e6a5. The error was not detected because the original binary (old name) was still present in the cache.