### PR TITLE
Centralize (de)spawning logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,7 +2279,6 @@ version = "0.1.0-dev"
 dependencies = [
  "ahash 0.8.3",
  "bevy",
- "de_audio",
  "de_core",
  "de_index",
  "de_objects",
@@ -2297,7 +2296,6 @@ version = "0.1.0-dev"
 dependencies = [
  "ahash 0.8.3",
  "bevy",
- "de_audio",
  "de_behaviour",
  "de_camera",
  "de_combat",
@@ -2643,6 +2641,7 @@ dependencies = [
  "de_index",
  "de_map",
  "de_objects",
+ "de_pathing",
  "de_terrain",
  "de_types",
  "parry2d",

--- a/crates/construction/Cargo.toml
+++ b/crates/construction/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 
 [dependencies]
 # DE
-de_audio.workspace = true
 de_core.workspace = true
 de_index.workspace = true
 de_objects.workspace = true

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 
 [dependencies]
 # DE
-de_audio.workspace = true
 de_behaviour.workspace = true
 de_camera.workspace = true
 de_combat.workspace = true

--- a/crates/controller/src/draft.rs
+++ b/crates/controller/src/draft.rs
@@ -1,12 +1,10 @@
 use bevy::prelude::*;
-use de_audio::spatial::{PlaySpatialAudioEvent, Sound};
 use de_core::{
     cleanup::DespawnOnGameExit, gamestate::GameState, gconfig::GameConfig,
-    objects::ObjectTypeComponent, player::PlayerComponent, schedule::InputSchedule,
-    state::AppState,
+    objects::ObjectTypeComponent, schedule::InputSchedule, state::AppState,
 };
-use de_spawner::{DraftAllowed, DraftBundle, SpawnBundle};
-use de_types::objects::BuildingType;
+use de_spawner::{DraftAllowed, DraftBundle, SpawnLocalActiveEvent};
+use de_types::objects::{BuildingType, ObjectType};
 
 use crate::mouse::{Pointer, PointerSet};
 
@@ -78,20 +76,19 @@ fn spawn(
     mut commands: Commands,
     game_config: Res<GameConfig>,
     drafts: Query<(Entity, &Transform, &ObjectTypeComponent, &DraftAllowed)>,
-    mut play_audio: EventWriter<PlaySpatialAudioEvent>,
+    mut spawn_active_events: EventWriter<SpawnLocalActiveEvent>,
 ) {
     for (entity, &transform, &object_type, draft) in drafts.iter() {
         if draft.allowed() {
             commands.entity(entity).despawn_recursive();
-            commands.spawn((
-                SpawnBundle::new(*object_type, transform),
-                PlayerComponent::from(game_config.locals().playable()),
-                DespawnOnGameExit,
-            ));
+            let ObjectType::Active(object_type) = *object_type else {
+                panic!("Cannot place draft of an inactive object.");
+            };
 
-            play_audio.send(PlaySpatialAudioEvent::new(
-                Sound::Construct,
-                transform.translation,
+            spawn_active_events.send(SpawnLocalActiveEvent::stationary(
+                object_type,
+                transform,
+                game_config.locals().playable(),
             ));
         }
     }

--- a/crates/core/src/objects.rs
+++ b/crates/core/src/objects.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use bevy::prelude::*;
 use de_types::objects::ObjectType;
 
-/// Active object which can be played by any player.
+/// Active object which can be played by any player (including AI).
 #[derive(Component)]
 pub struct Active;
 

--- a/crates/spawner/Cargo.toml
+++ b/crates/spawner/Cargo.toml
@@ -22,6 +22,7 @@ de_energy.workspace = true
 de_index.workspace = true
 de_map.workspace = true
 de_objects.workspace = true
+de_pathing.workspace = true
 de_terrain.workspace = true
 de_types.workspace = true
 

--- a/crates/spawner/src/lib.rs
+++ b/crates/spawner/src/lib.rs
@@ -3,12 +3,12 @@
 use bevy::{app::PluginGroupBuilder, prelude::*};
 use counter::CounterPlugin;
 pub use counter::ObjectCounter;
-pub use despawner::{DespawnEvent, DespawnEventsPlugin, DespawnedComponentsEvent, DespawnerSet};
+pub use despawner::{DespawnEventsPlugin, DespawnedComponentsEvent, DespawnerSet};
 use draft::DraftPlugin;
 pub use draft::{DraftAllowed, DraftBundle};
 use gameend::GameEndPlugin;
-pub use spawner::SpawnBundle;
 use spawner::SpawnerPlugin;
+pub use spawner::{SpawnInactiveEvent, SpawnLocalActiveEvent, SpawnerSet};
 
 use crate::despawner::DespawnerPlugin;
 

--- a/crates/spawner/src/spawner.rs
+++ b/crates/spawner/src/spawner.rs
@@ -1,16 +1,22 @@
 #![allow(clippy::forget_non_drop)] // Needed because of #[derive(Bundle)]
 
 use bevy::prelude::*;
+use de_audio::spatial::{PlaySpatialAudioEvent, Sound};
 use de_core::{
-    gamestate::GameState,
+    cleanup::DespawnOnGameExit,
     gconfig::GameConfig,
     objects::{Active, MovableSolid, ObjectTypeComponent, Playable, StaticSolid},
     player::PlayerComponent,
+    state::AppState,
 };
 use de_energy::Battery;
 use de_objects::{AssetCollection, InitialHealths, SceneType, Scenes, SolidObjects};
+use de_pathing::{PathTarget, UpdateEntityPathEvent};
 use de_terrain::{CircleMarker, MarkerVisibility, RectangleMarker};
-use de_types::objects::{ActiveObjectType, ObjectType};
+use de_types::{
+    objects::{ActiveObjectType, InactiveObjectType, ObjectType},
+    player::Player,
+};
 
 use crate::ObjectCounter;
 
@@ -18,100 +24,231 @@ pub(crate) struct SpawnerPlugin;
 
 impl Plugin for SpawnerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, spawn.run_if(in_state(GameState::Playing)));
+        app.add_event::<SpawnLocalActiveEvent>()
+            .add_event::<SpawnActiveEvent>()
+            .add_event::<SpawnInactiveEvent>()
+            .add_event::<SpawnEvent>()
+            .add_systems(
+                Update,
+                (
+                    spawn_local_active.before(spawn_active),
+                    spawn_active.before(spawn),
+                    spawn_inactive.before(spawn),
+                    spawn,
+                )
+                    .in_set(SpawnerSet::Spawner)
+                    .run_if(in_state(AppState::InGame)),
+            );
     }
 }
 
-#[derive(Bundle)]
-pub struct SpawnBundle {
-    object_type: ObjectTypeComponent,
-    transform: Transform,
-    global_transform: GlobalTransform,
-    visibility: Visibility,
-    computed_visibility: ComputedVisibility,
-    spawn: Spawn,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SystemSet)]
+pub enum SpawnerSet {
+    Spawner,
 }
 
-impl SpawnBundle {
-    pub fn new(object_type: ObjectType, transform: Transform) -> Self {
+/// Send this event to spawn a new locally simulated active object.
+#[derive(Event)]
+pub struct SpawnLocalActiveEvent {
+    object_type: ActiveObjectType,
+    transform: Transform,
+    player: Player,
+    path_target: Option<PathTarget>,
+}
+
+impl SpawnLocalActiveEvent {
+    pub fn stationary(object_type: ActiveObjectType, transform: Transform, player: Player) -> Self {
+        Self::new(object_type, transform, player, None)
+    }
+
+    pub fn new(
+        object_type: ActiveObjectType,
+        transform: Transform,
+        player: Player,
+        path_target: Option<PathTarget>,
+    ) -> Self {
         Self {
-            object_type: object_type.into(),
+            object_type,
             transform,
-            global_transform: transform.into(),
-            visibility: Visibility::Inherited,
-            computed_visibility: ComputedVisibility::HIDDEN,
-            spawn: Spawn,
+            player,
+            path_target,
         }
     }
 }
 
-#[derive(Component)]
-struct Spawn;
+#[derive(Event)]
+struct SpawnActiveEvent {
+    entity: Entity,
+    object_type: ActiveObjectType,
+    transform: Transform,
+    player: Player,
+}
 
-fn spawn(
+impl SpawnActiveEvent {
+    fn new(
+        entity: Entity,
+        object_type: ActiveObjectType,
+        transform: Transform,
+        player: Player,
+    ) -> Self {
+        Self {
+            entity,
+            object_type,
+            transform,
+            player,
+        }
+    }
+}
+
+/// Send this event to spawn an inactive object.
+#[derive(Event)]
+pub struct SpawnInactiveEvent {
+    object_type: InactiveObjectType,
+    transform: Transform,
+}
+
+impl SpawnInactiveEvent {
+    pub fn new(object_type: InactiveObjectType, transform: Transform) -> Self {
+        Self {
+            object_type,
+            transform,
+        }
+    }
+}
+
+#[derive(Event)]
+struct SpawnEvent {
+    entity: Entity,
+    object_type: ObjectType,
+    transform: Transform,
+}
+
+impl SpawnEvent {
+    fn new(entity: Entity, object_type: ObjectType, transform: Transform) -> Self {
+        Self {
+            entity,
+            object_type,
+            transform,
+        }
+    }
+}
+
+fn spawn_local_active(
     mut commands: Commands,
-    game_config: Res<GameConfig>,
-    scenes: Res<Scenes>,
+    config: Res<GameConfig>,
+    mut event_reader: EventReader<SpawnLocalActiveEvent>,
+    mut event_writer: EventWriter<SpawnActiveEvent>,
+    mut path_events: EventWriter<UpdateEntityPathEvent>,
+) {
+    for event in event_reader.iter() {
+        let mut entity_commands = commands.spawn_empty();
+
+        if config.locals().is_playable(event.player) || cfg!(feature = "godmode") {
+            entity_commands.insert(Playable);
+        }
+
+        let entity = entity_commands.id();
+        event_writer.send(SpawnActiveEvent::new(
+            entity,
+            event.object_type,
+            event.transform,
+            event.player,
+        ));
+
+        if let Some(path_target) = event.path_target {
+            path_events.send(UpdateEntityPathEvent::new(entity, path_target));
+        }
+    }
+}
+
+fn spawn_active(
+    mut commands: Commands,
+    mut counter: ResMut<ObjectCounter>,
     solids: SolidObjects,
     healths: Res<InitialHealths>,
-    mut counter: ResMut<ObjectCounter>,
-    to_spawn: Query<
-        (
-            Entity,
-            &ObjectTypeComponent,
-            &GlobalTransform,
-            Option<&PlayerComponent>,
-        ),
-        With<Spawn>,
-    >,
+    mut event_reader: EventReader<SpawnActiveEvent>,
+    mut event_writer: EventWriter<SpawnEvent>,
+    mut audio_events: EventWriter<PlaySpatialAudioEvent>,
 ) {
-    for (entity, &object_type, transform, player) in to_spawn.iter() {
-        info!("Spawning object {}", object_type);
+    for event in event_reader.iter() {
+        counter
+            .player_mut(event.player)
+            .update(event.object_type, 1);
 
-        let mut entity_commands = commands.entity(entity);
-        entity_commands
-            .remove::<Spawn>()
-            .insert(scenes.get(SceneType::Solid(*object_type)).clone());
+        let mut entity_commands = commands.entity(event.entity);
+        entity_commands.insert((
+            Active,
+            PlayerComponent::from(event.player),
+            Battery::default(),
+            MarkerVisibility::default(),
+            healths.health(event.object_type).clone(),
+        ));
 
-        let solid = solids.get(*object_type);
-        match *object_type {
-            ObjectType::Active(active_type) => {
-                entity_commands.insert(Active);
-                entity_commands.insert(Battery::default());
+        let solid = solids.get(ObjectType::Active(event.object_type));
+        match event.object_type {
+            ActiveObjectType::Building(_) => {
+                let local_aabb = solid.ichnography().local_aabb();
+                entity_commands.insert((
+                    StaticSolid,
+                    RectangleMarker::from_aabb_transform(local_aabb, &event.transform),
+                ));
 
-                let player = *player.expect("Active object without an associated was spawned.");
-                counter.player_mut(*player).update(active_type, 1);
-
-                if game_config.locals().is_playable(*player) || cfg!(feature = "godmode") {
-                    entity_commands.insert(Playable);
-                }
-
-                match active_type {
-                    ActiveObjectType::Building(_) => {
-                        entity_commands.insert(StaticSolid);
-
-                        let local_aabb = solid.ichnography().local_aabb();
-                        entity_commands
-                            .insert(RectangleMarker::from_aabb_transform(local_aabb, transform));
-                    }
-                    ActiveObjectType::Unit(_) => {
-                        entity_commands.insert(MovableSolid);
-
-                        let radius = solid.ichnography().radius();
-                        entity_commands.insert(CircleMarker::new(radius));
-                    }
-                }
-
-                entity_commands.insert(MarkerVisibility::default());
-
-                entity_commands.insert(healths.health(active_type).clone());
-                if let Some(cannon) = solid.cannon() {
-                    entity_commands.insert(cannon.clone());
-                }
+                audio_events.send(PlaySpatialAudioEvent::new(
+                    Sound::Construct,
+                    event.transform.translation,
+                ));
             }
-            ObjectType::Inactive(_) => {
-                entity_commands.insert(StaticSolid);
+            ActiveObjectType::Unit(_) => {
+                let radius = solid.ichnography().radius();
+                entity_commands.insert((MovableSolid, CircleMarker::new(radius)));
+
+                audio_events.send(PlaySpatialAudioEvent::new(
+                    Sound::Manufacture,
+                    event.transform.translation,
+                ));
             }
         }
+
+        if let Some(cannon) = solid.cannon() {
+            entity_commands.insert(cannon.clone());
+        }
+
+        event_writer.send(SpawnEvent::new(
+            entity_commands.id(),
+            ObjectType::Active(event.object_type),
+            event.transform,
+        ));
+    }
+}
+
+fn spawn_inactive(
+    mut commands: Commands,
+    mut event_reader: EventReader<SpawnInactiveEvent>,
+    mut event_writer: EventWriter<SpawnEvent>,
+) {
+    for event in event_reader.iter() {
+        let entity = commands.spawn(StaticSolid).id();
+        event_writer.send(SpawnEvent::new(
+            entity,
+            ObjectType::Inactive(event.object_type),
+            event.transform,
+        ));
+    }
+}
+
+fn spawn(mut commands: Commands, scenes: Res<Scenes>, mut events: EventReader<SpawnEvent>) {
+    for event in events.iter() {
+        info!("Spawning object {}", event.object_type);
+        let mut entity_commands = commands.entity(event.entity);
+
+        entity_commands.insert((
+            event.transform,
+            GlobalTransform::from(event.transform),
+            Visibility::Inherited,
+            ComputedVisibility::default(),
+            ObjectTypeComponent::from(event.object_type),
+            scenes.get(SceneType::Solid(event.object_type)).clone(),
+            DespawnOnGameExit,
+        ));
     }
 }

--- a/crates/terrain/src/marker.rs
+++ b/crates/terrain/src/marker.rs
@@ -83,7 +83,7 @@ pub struct RectangleMarker {
 
 impl RectangleMarker {
     /// Creates a new rectangle marker.
-    pub fn new(transform: &GlobalTransform, half_size: Vec2) -> Self {
+    pub fn new(transform: &Transform, half_size: Vec2) -> Self {
         Self {
             inverse_transform: transform.compute_matrix().inverse().to_flat(),
             half_size,
@@ -91,7 +91,7 @@ impl RectangleMarker {
     }
 
     /// Creates a new rectangle marker with the size of the AABB plus a margin.
-    pub fn from_aabb_transform(local_aabb: Aabb, transform: &GlobalTransform) -> Self {
+    pub fn from_aabb_transform(local_aabb: Aabb, transform: &Transform) -> Self {
         let half_extents: Vec2 = local_aabb.half_extents().into();
         Self::new(
             transform,


### PR DESCRIPTION
This centralization and reorganization of (de)spawning logic paves the way for the multiplayer. There will be a single place where synchronization mechanizes would be embedded. Apart from that, the code is now cleaner organized and more DRY.