### PR TITLE
Simulate destruction & manufacturing only for local

### DIFF
--- a/crates/construction/src/manufacturing.rs
+++ b/crates/construction/src/manufacturing.rs
@@ -4,7 +4,7 @@ use ahash::AHashMap;
 use bevy::prelude::*;
 use de_core::{
     gamestate::GameState,
-    objects::{Active, ObjectTypeComponent},
+    objects::{Local, ObjectTypeComponent},
     player::PlayerComponent,
     state::AppState,
 };
@@ -292,7 +292,7 @@ impl ProductionItem {
 fn configure(
     mut commands: Commands,
     solids: SolidObjects,
-    new: Query<(Entity, &Transform, &ObjectTypeComponent), Added<Active>>,
+    new: Query<(Entity, &Transform, &ObjectTypeComponent), Added<Local>>,
     mut pole_events: EventWriter<UpdatePoleLocationEvent>,
     mut line_events: EventWriter<UpdateLineLocationEvent>,
 ) {

--- a/crates/spawner/src/despawner.rs
+++ b/crates/spawner/src/despawner.rs
@@ -3,7 +3,11 @@ use std::marker::PhantomData;
 use bevy::ecs::query::{ReadOnlyWorldQuery, WorldQuery};
 use bevy::prelude::*;
 use de_audio::spatial::{PlaySpatialAudioEvent, Sound};
-use de_core::{objects::ObjectTypeComponent, player::PlayerComponent, state::AppState};
+use de_core::{
+    objects::{Local, ObjectTypeComponent},
+    player::PlayerComponent,
+    state::AppState,
+};
 use de_objects::Health;
 use de_types::objects::{ActiveObjectType, ObjectType};
 
@@ -50,9 +54,12 @@ struct DespawnActiveEvent(Entity);
 #[derive(Event)]
 struct DespawnEvent(Entity);
 
+type LocallyChangedHealth<'w, 's> =
+    Query<'w, 's, (Entity, &'static Health), (With<Local>, Changed<Health>)>;
+
 /// Find all entities with low health and mark them for despawning
 fn find_dead(
-    entities: Query<(Entity, &Health), Changed<Health>>,
+    entities: LocallyChangedHealth,
     mut event_writer: EventWriter<DespawnActiveLocalEvent>,
 ) {
     for (entity, health) in entities.iter() {


### PR DESCRIPTION
This will be necessary during a multiplayer game to avoid desync (the authority is the local simulation).