### PR TITLE
de_messages: Remove an unnecessary impl

### DIFF
--- a/crates/messages/src/players/entity.rs
+++ b/crates/messages/src/players/entity.rs
@@ -3,14 +3,8 @@ use bevy::ecs::entity::Entity;
 use bincode::{Decode, Encode};
 
 /// Bevy ECS Entity derived identification of an entity.
-#[derive(Debug, Encode, Decode)]
+#[derive(Clone, Copy, Debug, Encode, Decode, Hash, PartialEq, Eq)]
 pub struct EntityNet(u32);
-
-impl EntityNet {
-    pub fn index(&self) -> u32 {
-        self.0
-    }
-}
 
 #[cfg(feature = "bevy")]
 impl From<Entity> for EntityNet {


### PR DESCRIPTION
No need to make the index transparent as long as once can easily use the entity directly in e.g. a hash map.