### PR TITLE
de_spawner: Fix an ECS query

### DIFF
--- a/crates/spawner/src/despawner.rs
+++ b/crates/spawner/src/despawner.rs
@@ -103,7 +103,7 @@ fn despawn_active_remote(
 
 fn despawn_active(
     mut counter: ResMut<ObjectCounter>,
-    entities: Query<(&PlayerComponent, &ObjectTypeComponent, &Transform), Changed<Health>>,
+    entities: Query<(&PlayerComponent, &ObjectTypeComponent, &Transform)>,
     mut event_reader: EventReader<DespawnActiveEvent>,
     mut event_writer: EventWriter<DespawnEvent>,
     mut play_audio: EventWriter<PlaySpatialAudioEvent>,


### PR DESCRIPTION
Despawning must work on all entities, including those without changed health.