### PR TITLE
Multiplayer: Make non-local entity updates possible

### DIFF
--- a/crates/messages/src/players/entity.rs
+++ b/crates/messages/src/players/entity.rs
@@ -1,14 +1,21 @@
-#[cfg(feature = "bevy")]
-use bevy::ecs::entity::Entity;
 use bincode::{Decode, Encode};
+use de_types::player::Player;
 
 /// Bevy ECS Entity derived identification of an entity.
 #[derive(Clone, Copy, Debug, Encode, Decode, Hash, PartialEq, Eq)]
-pub struct EntityNet(u32);
+pub struct EntityNet {
+    player: Player,
+    index: u32,
+}
 
-#[cfg(feature = "bevy")]
-impl From<Entity> for EntityNet {
-    fn from(entity: Entity) -> Self {
-        Self(entity.index())
+impl EntityNet {
+    /// # Arguments
+    ///
+    /// * `player` - the human player executing the entity simulating game
+    ///   instance.
+    ///
+    /// * `index` - locally unique index of the entity.
+    pub fn new(player: Player, index: u32) -> Self {
+        Self { player, index }
     }
 }

--- a/crates/multiplayer/src/lib.rs
+++ b/crates/multiplayer/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
     lifecycle::{MultiplayerShuttingDownEvent, ShutdownMultiplayerEvent, StartMultiplayerEvent},
     messages::{MessagesSet, ToPlayersEvent},
     netstate::NetState,
-    playermsg::{GameNetSet, NetRecvDespawnActiveEvent, NetRecvSpawnActiveEvent},
+    playermsg::{GameNetSet, NetEntities, NetRecvDespawnActiveEvent, NetRecvSpawnActiveEvent},
 };
 use crate::{netstate::NetStatePlugin, network::NetworkPlugin};
 

--- a/crates/spawner/src/despawner.rs
+++ b/crates/spawner/src/despawner.rs
@@ -10,7 +10,7 @@ use de_core::{
     state::AppState,
 };
 use de_messages::ToPlayers;
-use de_multiplayer::{NetRecvDespawnActiveEvent, ToPlayersEvent};
+use de_multiplayer::{NetEntities, NetRecvDespawnActiveEvent, ToPlayersEvent};
 use de_objects::Health;
 use de_types::objects::{ActiveObjectType, ObjectType};
 
@@ -77,6 +77,7 @@ fn find_dead(
 
 fn despawn_active_local(
     config: Res<GameConfig>,
+    net_entities: NetEntities,
     mut event_reader: EventReader<DespawnActiveLocalEvent>,
     mut event_writer: EventWriter<DespawnActiveEvent>,
     mut net_events: EventWriter<ToPlayersEvent>,
@@ -86,7 +87,7 @@ fn despawn_active_local(
 
         if config.multiplayer() {
             net_events.send(ToPlayersEvent::new(ToPlayers::Despawn {
-                entity: event.0.into(),
+                entity: net_entities.local_net_id(event.0),
             }));
         }
     }

--- a/crates/spawner/src/spawner.rs
+++ b/crates/spawner/src/spawner.rs
@@ -11,7 +11,7 @@ use de_core::{
 };
 use de_energy::Battery;
 use de_messages::ToPlayers;
-use de_multiplayer::{NetRecvSpawnActiveEvent, ToPlayersEvent};
+use de_multiplayer::{NetEntities, NetRecvSpawnActiveEvent, ToPlayersEvent};
 use de_objects::{AssetCollection, InitialHealths, SceneType, Scenes, SolidObjects};
 use de_pathing::{PathTarget, UpdateEntityPathEvent};
 use de_terrain::{CircleMarker, MarkerVisibility, RectangleMarker};
@@ -141,6 +141,7 @@ impl SpawnEvent {
 fn spawn_local_active(
     mut commands: Commands,
     config: Res<GameConfig>,
+    net_entities: NetEntities,
     mut event_reader: EventReader<SpawnLocalActiveEvent>,
     mut event_writer: EventWriter<SpawnActiveEvent>,
     mut path_events: EventWriter<UpdateEntityPathEvent>,
@@ -167,7 +168,7 @@ fn spawn_local_active(
 
         if config.multiplayer() {
             net_events.send(ToPlayersEvent::new(ToPlayers::Spawn {
-                entity: entity.into(),
+                entity: net_entities.local_net_id(entity),
                 player: event.player,
                 object_type: event.object_type,
                 transform: event.transform.into(),


### PR DESCRIPTION
This PR makes it possible to send a network message regarding a non-locally simulated entity. This will be needed during e.g. health updates (triggered by a locally simulated attacking entity).