### PR TITLE
Centralize entity health management

### DIFF
--- a/crates/combat/src/health.rs
+++ b/crates/combat/src/health.rs
@@ -1,0 +1,107 @@
+use bevy::prelude::*;
+use de_core::{objects::Local, state::AppState};
+use de_objects::Health;
+use de_signs::UpdateBarValueEvent;
+use de_spawner::{DespawnActiveLocalEvent, DespawnerSet};
+
+pub(crate) struct HealthPlugin;
+
+impl Plugin for HealthPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<LocalUpdateHealthEvent>()
+            .add_event::<UpdateHealthEvent>()
+            .add_systems(
+                Update,
+                (
+                    (
+                        update_local_health
+                            .run_if(on_event::<LocalUpdateHealthEvent>())
+                            .before(update_health),
+                        update_health.run_if(on_event::<UpdateHealthEvent>()),
+                    )
+                        .in_set(HealthSet::Update),
+                    find_dead
+                        .after(HealthSet::Update)
+                        .before(DespawnerSet::Despawn),
+                )
+                    .run_if(in_state(AppState::InGame)),
+            );
+    }
+}
+
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, SystemSet)]
+pub(crate) enum HealthSet {
+    Update,
+}
+
+/// Send this event to change health as a result of actions of locally
+/// simulated entity.
+#[derive(Event)]
+pub(crate) struct LocalUpdateHealthEvent {
+    entity: Entity,
+    delta: f32,
+}
+
+impl LocalUpdateHealthEvent {
+    /// # Panics
+    ///
+    /// Panics if health delta is not finite.
+    pub(crate) fn new(entity: Entity, delta: f32) -> Self {
+        assert!(delta.is_finite());
+        Self { entity, delta }
+    }
+}
+
+/// Send this event to change health of any entity.
+#[derive(Event)]
+struct UpdateHealthEvent {
+    entity: Entity,
+    delta: f32,
+}
+
+impl UpdateHealthEvent {
+    /// # Panics
+    ///
+    /// Panics if health delta is not finite.
+    fn new(entity: Entity, delta: f32) -> Self {
+        assert!(delta.is_finite());
+        Self { entity, delta }
+    }
+}
+
+fn update_local_health(
+    mut in_events: EventReader<LocalUpdateHealthEvent>,
+    mut out_events: EventWriter<UpdateHealthEvent>,
+) {
+    for event in in_events.iter() {
+        out_events.send(UpdateHealthEvent::new(event.entity, event.delta));
+    }
+}
+
+fn update_health(
+    mut healths: Query<&mut Health>,
+    mut health_events: EventReader<UpdateHealthEvent>,
+    mut bar_events: EventWriter<UpdateBarValueEvent>,
+) {
+    for event in health_events.iter() {
+        let Ok(mut health) = healths.get_mut(event.entity) else {
+            continue;
+        };
+        health.update(event.delta);
+        bar_events.send(UpdateBarValueEvent::new(event.entity, health.fraction()));
+    }
+}
+
+type LocallyChangedHealth<'w, 's> =
+    Query<'w, 's, (Entity, &'static Health), (With<Local>, Changed<Health>)>;
+
+fn find_dead(
+    entities: LocallyChangedHealth,
+    mut event_writer: EventWriter<DespawnActiveLocalEvent>,
+) {
+    for (entity, health) in entities.iter() {
+        if health.destroyed() {
+            event_writer.send(DespawnActiveLocalEvent::new(entity));
+        }
+    }
+}

--- a/crates/combat/src/lib.rs
+++ b/crates/combat/src/lib.rs
@@ -4,10 +4,12 @@ use bevy::{
     app::PluginGroupBuilder,
     prelude::{PluginGroup, SystemSet},
 };
+use health::HealthPlugin;
 use laser::LaserPlugin;
 use trail::TrailPlugin;
 
 mod attack;
+mod health;
 mod laser;
 mod sightline;
 mod trail;
@@ -20,6 +22,7 @@ impl PluginGroup for CombatPluginGroup {
             .add(LaserPlugin)
             .add(AttackPlugin)
             .add(TrailPlugin)
+            .add(HealthPlugin)
     }
 }
 

--- a/crates/objects/src/health.rs
+++ b/crates/objects/src/health.rs
@@ -70,17 +70,14 @@ impl Health {
     ///
     /// # Arguments
     ///
-    /// * `damage` - amount of damage, i.e. by how much is the health
-    ///   decreased. This has to be a non-negative finite number or positive
-    ///   infinity.
+    /// * `delta` - amount of change, i.e. by how much is the health increased.
     ///
     /// # Panics
     ///
-    /// This method might panic if `damage` is not a non-negative finite number
-    /// or positive infinity.
-    pub fn hit(&mut self, damage: f32) {
-        debug_assert!(damage >= 0.);
-        self.health = 0f32.max(self.health - damage);
+    /// This method might panic if `delta` is not a finite number.
+    pub fn update(&mut self, delta: f32) {
+        debug_assert!(delta.is_finite());
+        self.health = (self.health + delta).clamp(0., self.max);
     }
 
     pub fn destroyed(&self) -> bool {

--- a/crates/spawner/src/lib.rs
+++ b/crates/spawner/src/lib.rs
@@ -3,7 +3,9 @@
 use bevy::{app::PluginGroupBuilder, prelude::*};
 use counter::CounterPlugin;
 pub use counter::ObjectCounter;
-pub use despawner::{DespawnEventsPlugin, DespawnedComponentsEvent, DespawnerSet};
+pub use despawner::{
+    DespawnActiveLocalEvent, DespawnEventsPlugin, DespawnedComponentsEvent, DespawnerSet,
+};
 use draft::DraftPlugin;
 pub use draft::{DraftAllowed, DraftBundle};
 use gameend::GameEndPlugin;


### PR DESCRIPTION
Centralization of the logic makes the code better organized and easier to extend or modified. It is a stepping stone for over network health synchronization.