### PR TITLE
de_connector: Return non-zero exit code on failure

### DIFF
--- a/crates/connector/src/lib.rs
+++ b/crates/connector/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use async_std::task;
 use de_net::Socket;
-use tracing::{error, info};
+use tracing::info;
 
 use crate::server::MainServer;
 
@@ -11,14 +11,11 @@ mod server;
 
 const PORT: u16 = 8082;
 
-pub fn start() {
+pub fn start() -> Result<(), String> {
     info!("Starting...");
-
     task::block_on(task::spawn(async {
-        if let Err(error) = start_inner().await {
-            error!("{:?}", error);
-        }
-    }));
+        start_inner().await.map_err(|error| format!("{:?}", error))
+    }))
 }
 
 async fn start_inner() -> anyhow::Result<()> {

--- a/crates/connector/src/main.rs
+++ b/crates/connector/src/main.rs
@@ -1,11 +1,17 @@
 use de_connector_lib::start;
-use tracing::Level;
+use tracing::{error, Level};
 use tracing_subscriber::FmtSubscriber;
 
-fn main() {
+fn main() -> Result<(), String> {
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::TRACE)
         .finish();
     tracing::subscriber::set_global_default(subscriber).unwrap();
-    start();
+
+    let result = start();
+    if let Err(message) = result.as_ref() {
+        error!(message);
+    }
+
+    result
 }


### PR DESCRIPTION
This is crutial for e.g. systemd units so that they can restart the service on-failure.