### PR TITLE
CI: Fix udeps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,6 @@ jobs:
         id: rust-cache
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -103,7 +102,8 @@ jobs:
           echo $UDEPS_VER
           curl -L "https://github.com/est31/cargo-udeps/releases/download/$UDEPS_VER/cargo-udeps-$UDEPS_VER-x86_64-unknown-linux-gnu.tar.gz" -o udeps.tar.gz
           tar -xzvf udeps.tar.gz
-          ./cargo-udeps-$UDEPS_VER-x86_64-unknown-linux-gnu/cargo-udeps udeps
+          cp ./cargo-udeps-$UDEPS_VER-x86_64-unknown-linux-gnu/cargo-udeps ~/.cargo/bin/
+          cargo +nightly udeps
 
   comments:
     name: Code Comments


### PR DESCRIPTION
This fixes the following error from CI:

```
error: the option `Z` is only accepted on the nightly compiler

note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>

help: consider switching to a nightly toolchain: `rustup default nightly`

note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>

error: could not compile `sharded-slab` (lib)
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

Relates to https://github.com/est31/cargo-udeps/issues/104 (one needs to pass +nightly to `cargo` so that correct / necessary rustc is used).