### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -4,7 +4,8 @@
 pub use game::{FromGame, JoinError, Readiness, ToGame};
 pub use players::{
     BorrowedFromPlayers, ChatMessage, ChatMessageError, EntityNet, FromPlayers, HealthDelta,
-    NetEntityIndex, NetProjectile, ToPlayers, MAX_CHAT_LEN,
+    NetEntityIndex, NetProjectile, PathError, PathNet, ToPlayers, TransformNet, Vec2Net, Vec3Net,
+    Vec4Net, MAX_CHAT_LEN,
 };
 pub use server::{FromServer, GameOpenError, ToServer};
 


### PR DESCRIPTION
```
error: unused import: `Vec4Net`
 --> crates/messages/src/players/mod.rs:5:48
  |
5 | pub use geom::{TransformNet, Vec2Net, Vec3Net, Vec4Net};
  |                                                ^^^^^^^
  |
  = note: `-D unused-imports` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: unused import: `PathError`
 --> crates/messages/src/players/mod.rs:6:16
  |
6 | pub use path::{PathError, PathNet};
  |                ^^^^^^^^^
```