### PR TITLE
Add basic enemy colors to minimap

### DIFF
--- a/crates/controller/src/hud/minimap/fill.rs
+++ b/crates/controller/src/hud/minimap/fill.rs
@@ -6,7 +6,11 @@ use de_core::{
 use de_map::size::MapBounds;
 use de_objects::SolidObjects;
 use de_terrain::TerrainCollider;
-use de_types::{objects::*, player::Player, projection::ToFlat};
+use de_types::{
+    objects::{ActiveObjectType, ObjectType},
+    player::Player,
+    projection::ToFlat,
+};
 use parry2d::{
     bounding_volume::Aabb,
     math::Point,

--- a/crates/controller/src/hud/minimap/fill.rs
+++ b/crates/controller/src/hud/minimap/fill.rs
@@ -1,5 +1,3 @@
-use super::draw::DrawingParam;
-use crate::ray::ScreenRay;
 use bevy::{ecs::system::SystemParam, prelude::*};
 use de_core::{
     gamestate::GameState, objects::ObjectTypeComponent, player::PlayerComponent,
@@ -15,6 +13,9 @@ use parry2d::{
     query::{Ray, RayCast},
 };
 
+use super::draw::DrawingParam;
+use crate::ray::ScreenRay;
+
 const TERRAIN_COLOR: Color = Color::rgb(0.61, 0.46, 0.32);
 const PLAYER_COLORS: [Color; Player::MAX_PLAYERS] = [
     Color::rgb(0.1, 0.1, 0.9),
@@ -27,6 +28,7 @@ const CAMERA_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
 
 #[derive(Resource, Debug)]
 struct PlayerColors([Color; Player::MAX_PLAYERS]);
+
 impl PlayerColors {
     fn get_color(&self, player: Player, object_type: ActiveObjectType) -> Color {
         let player_idx: usize = (player.to_num() - 1) as usize;
@@ -37,6 +39,7 @@ impl PlayerColors {
         }
     }
 }
+
 impl Default for PlayerColors {
     fn default() -> Self {
         Self(PLAYER_COLORS)


### PR DESCRIPTION
Fixes #584.

All players are assigned a color based on their player number. It also changes the color of the units slightly to distinguish them from buildings.

In the future I think it would be nice that each player could choose their color from a list of curated colors that are visually distinctive, and then they would always be consistent across single player or multiplayer views. Or they are assigned a color, but then the UI would need to change in other ways so they would know which color they were assigned. This could be as simple as a color bar next to the their name in the game list, or some other color indicator in the HUD.

I'm just learning Rust and Bevy, so hopefully I did things properly. Let me know if you would like any changes.